### PR TITLE
ts-fix --interactiveMode, --ignoreGitStatus, --file, --showMultiple

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // See: https://github.com/microsoft/TypeScript/wiki/Debugging-Language-Service-in-VS-Code
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to VS Code TS Server via Port",
+            "processId": "${command:PickProcess}",
+            // "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue",
+          }
+
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "import-cwd": "^3.0.0",
         "inquirer": "^8.0.0",
         "lodash": "^4.17.21",
-        "typescript": "4.9.0-dev.20220812",
+        "typescript": "4.9.0-dev.20220816",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -8299,9 +8299,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.0-dev.20220812",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220812.tgz",
-      "integrity": "sha512-Rx+XQMKra4nR6w4+EiFoips3VCOWAlVKiWUbTpaFOAGb74h1pxWbxXmqpDOe/g3KSKMdYmN4dr7umrglumNAdw==",
+      "version": "4.9.0-dev.20220816",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220816.tgz",
+      "integrity": "sha512-jNu5zDQoA3R0z7pQLGIfpeI3Z5L4M0hdDCGhIAp0wlUrAIyo6fdOD2Vx4Cpv/Y4W55RzQB709KKqh4dDbnIssg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15028,9 +15028,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.0-dev.20220812",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220812.tgz",
-      "integrity": "sha512-Rx+XQMKra4nR6w4+EiFoips3VCOWAlVKiWUbTpaFOAGb74h1pxWbxXmqpDOe/g3KSKMdYmN4dr7umrglumNAdw=="
+      "version": "4.9.0-dev.20220816",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220816.tgz",
+      "integrity": "sha512-jNu5zDQoA3R0z7pQLGIfpeI3Z5L4M0hdDCGhIAp0wlUrAIyo6fdOD2Vx4Cpv/Y4W55RzQB709KKqh4dDbnIssg=="
     },
     "typpy": {
       "version": "2.3.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "diff": "^5.1.0",
+        "git-status": "^1.0.10",
         "import-cwd": "^3.0.0",
         "inquirer": "^8.0.0",
         "lodash": "^4.17.21",
-        "typescript": "4.8.0-dev.20220731",
+        "typescript": "4.9.0-dev.20220812",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -1725,9 +1726,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -2531,6 +2532,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deffy": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.4.tgz",
+      "integrity": "sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==",
+      "dependencies": {
+        "typpy": "^2.0.0"
       }
     },
     "node_modules/define-properties": {
@@ -3476,6 +3485,14 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "node_modules/function.name": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.13.tgz",
+      "integrity": "sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==",
+      "dependencies": {
+        "noop6": "^1.0.1"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3535,6 +3552,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/git-status": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/git-status/-/git-status-1.0.10.tgz",
+      "integrity": "sha512-bxV60hbzMRjY/JarILltdppkfov0FcGyb9uytHjN7tjBFiibdhBJTddlxpaoBneQuDGem8vQy6UJ+SU89l7NlQ==",
+      "dependencies": {
+        "oargv": "^3.4.2",
+        "parse-git-status": "^0.1.0",
+        "spawno": "^1.0.1"
       }
     },
     "node_modules/glob": {
@@ -4334,6 +4361,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterate-object": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.4.tgz",
+      "integrity": "sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw=="
     },
     "node_modules/jest": {
       "version": "27.0.6",
@@ -6793,9 +6825,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -6889,6 +6921,11 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
     },
+    "node_modules/noop6": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.9.tgz",
+      "integrity": "sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA=="
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6924,6 +6961,15 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "node_modules/oargv": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/oargv/-/oargv-3.4.10.tgz",
+      "integrity": "sha512-SXaMANv9sr7S/dP0vj0+Ybipa47UE1ntTWQ2rpPRhC6Bsvfl+Jg03Xif7jfL0sWKOYWK8oPjcZ5eJ82t8AP/8g==",
+      "dependencies": {
+        "iterate-object": "^1.1.0",
+        "ul": "^5.0.0"
+      }
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
@@ -7107,6 +7153,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-git-status": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/parse-git-status/-/parse-git-status-0.1.0.tgz",
+      "integrity": "sha512-ngjxaxWtYrNIDYUWrCDcSAgtai3sELojyTauZVMyawYf+J9Cd6BvGQ/clGXrpmmFXkXj81E5zbOkGt8afsb+dw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -7288,6 +7342,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/proc-output": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/proc-output/-/proc-output-1.0.8.tgz",
+      "integrity": "sha512-d5v2wFTIrfE7eyt5KqB+CwsaBAmYqKIVNZv3R3Hya96gImHm2Aul+x6MZHRaKI7Ijpr9cg3RiOCY6s1O4SvzFQ=="
     },
     "node_modules/prompts": {
       "version": "2.4.1",
@@ -7870,6 +7929,14 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
+    "node_modules/spawno": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spawno/-/spawno-1.0.4.tgz",
+      "integrity": "sha512-euy9JLkCC2SvXNYZAi9WBTHDxbjSWNCaeLhLIH+BGW1Xb/3yKxoWOT2kanSS1a5wB0iukDYu79FJMNJsGW7azA==",
+      "dependencies": {
+        "proc-output": "^1.0.0"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8103,9 +8170,9 @@
       }
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -8232,15 +8299,32 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.0-dev.20220731",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220731.tgz",
-      "integrity": "sha512-RMnAFXQvFPMG1nOvMfnO0z1FvxKvH001GmBY14fXmX0DftaJvh4Huw8z/VWQF4IhWRSQr1tYo1+jwM2z6M/tZQ==",
+      "version": "4.9.0-dev.20220812",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220812.tgz",
+      "integrity": "sha512-Rx+XQMKra4nR6w4+EiFoips3VCOWAlVKiWUbTpaFOAGb74h1pxWbxXmqpDOe/g3KSKMdYmN4dr7umrglumNAdw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typpy": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.13.tgz",
+      "integrity": "sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==",
+      "dependencies": {
+        "function.name": "^1.0.3"
+      }
+    },
+    "node_modules/ul": {
+      "version": "5.2.15",
+      "resolved": "https://registry.npmjs.org/ul/-/ul-5.2.15.tgz",
+      "integrity": "sha512-svLEUy8xSCip5IWnsRa0UOg+2zP0Wsj4qlbjTmX6GJSmvKMHADBuHOm1dpNkWqWPIGuVSqzUkV3Cris5JrlTRQ==",
+      "dependencies": {
+        "deffy": "^2.2.2",
+        "typpy": "^2.3.4"
       }
     },
     "node_modules/union-value": {
@@ -9890,9 +9974,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -10535,6 +10619,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "deffy": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.4.tgz",
+      "integrity": "sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==",
+      "requires": {
+        "typpy": "^2.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -11258,6 +11350,14 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "function.name": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.13.tgz",
+      "integrity": "sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==",
+      "requires": {
+        "noop6": "^1.0.1"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -11297,6 +11397,16 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "git-status": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/git-status/-/git-status-1.0.10.tgz",
+      "integrity": "sha512-bxV60hbzMRjY/JarILltdppkfov0FcGyb9uytHjN7tjBFiibdhBJTddlxpaoBneQuDGem8vQy6UJ+SU89l7NlQ==",
+      "requires": {
+        "oargv": "^3.4.2",
+        "parse-git-status": "^0.1.0",
+        "spawno": "^1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.7",
@@ -11909,6 +12019,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterate-object": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.4.tgz",
+      "integrity": "sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw=="
     },
     "jest": {
       "version": "27.0.6",
@@ -13754,9 +13869,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -13840,6 +13955,11 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
     },
+    "noop6": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.9.tgz",
+      "integrity": "sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13868,6 +13988,15 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "oargv": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/oargv/-/oargv-3.4.10.tgz",
+      "integrity": "sha512-SXaMANv9sr7S/dP0vj0+Ybipa47UE1ntTWQ2rpPRhC6Bsvfl+Jg03Xif7jfL0sWKOYWK8oPjcZ5eJ82t8AP/8g==",
+      "requires": {
+        "iterate-object": "^1.1.0",
+        "ul": "^5.0.0"
+      }
     },
     "object-copy": {
       "version": "0.1.0",
@@ -13998,6 +14127,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "parse-git-status": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/parse-git-status/-/parse-git-status-0.1.0.tgz",
+      "integrity": "sha512-ngjxaxWtYrNIDYUWrCDcSAgtai3sELojyTauZVMyawYf+J9Cd6BvGQ/clGXrpmmFXkXj81E5zbOkGt8afsb+dw=="
     },
     "parse5": {
       "version": "6.0.1",
@@ -14131,6 +14265,11 @@
           }
         }
       }
+    },
+    "proc-output": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/proc-output/-/proc-output-1.0.8.tgz",
+      "integrity": "sha512-d5v2wFTIrfE7eyt5KqB+CwsaBAmYqKIVNZv3R3Hya96gImHm2Aul+x6MZHRaKI7Ijpr9cg3RiOCY6s1O4SvzFQ=="
     },
     "prompts": {
       "version": "2.4.1",
@@ -14595,6 +14734,14 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
+    "spawno": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spawno/-/spawno-1.0.4.tgz",
+      "integrity": "sha512-euy9JLkCC2SvXNYZAi9WBTHDxbjSWNCaeLhLIH+BGW1Xb/3yKxoWOT2kanSS1a5wB0iukDYu79FJMNJsGW7azA==",
+      "requires": {
+        "proc-output": "^1.0.0"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14777,9 +14924,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -14881,9 +15028,26 @@
       }
     },
     "typescript": {
-      "version": "4.8.0-dev.20220731",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220731.tgz",
-      "integrity": "sha512-RMnAFXQvFPMG1nOvMfnO0z1FvxKvH001GmBY14fXmX0DftaJvh4Huw8z/VWQF4IhWRSQr1tYo1+jwM2z6M/tZQ=="
+      "version": "4.9.0-dev.20220812",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.0-dev.20220812.tgz",
+      "integrity": "sha512-Rx+XQMKra4nR6w4+EiFoips3VCOWAlVKiWUbTpaFOAGb74h1pxWbxXmqpDOe/g3KSKMdYmN4dr7umrglumNAdw=="
+    },
+    "typpy": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.13.tgz",
+      "integrity": "sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==",
+      "requires": {
+        "function.name": "^1.0.3"
+      }
+    },
+    "ul": {
+      "version": "5.2.15",
+      "resolved": "https://registry.npmjs.org/ul/-/ul-5.2.15.tgz",
+      "integrity": "sha512-svLEUy8xSCip5IWnsRa0UOg+2zP0Wsj4qlbjTmX6GJSmvKMHADBuHOm1dpNkWqWPIGuVSqzUkV3Cris5JrlTRQ==",
+      "requires": {
+        "deffy": "^2.2.2",
+        "typpy": "^2.3.4"
+      }
     },
     "union-value": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,19 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "diff": "^5.1.0",
         "import-cwd": "^3.0.0",
+        "inquirer": "^8.0.0",
         "lodash": "^4.17.21",
-        "typescript": "^4.3.5",
+        "typescript": "4.8.0-dev.20220731",
         "yargs": "^16.2.0"
       },
       "bin": {
         "ts-fix": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/diff": "^5.0.2",
+        "@types/inquirer": "^8.2.1",
         "@types/jest": "^26.0.24",
         "@types/jest-specific-snapshot": "^0.5.5",
         "@types/lodash": "^4.14.171",
@@ -1507,6 +1511,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.2.tgz",
+      "integrity": "sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1514,6 +1524,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/inquirer": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.1.tgz",
+      "integrity": "sha512-wKW3SKIUMmltbykg4I5JzCVzUhkuD9trD6efAmYgN2MrSntY0SMRQzEnD3mkyJ/rv9NLbTC7g3hKKE86YwEDLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1582,6 +1602,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -1674,7 +1703,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -1689,7 +1717,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2224,15 +2251,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/chalk/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -2241,6 +2259,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -2279,6 +2302,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cliui": {
@@ -2570,6 +2612,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2969,6 +3019,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/escodegen": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
@@ -3215,6 +3273,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -3315,6 +3386,20 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -3663,7 +3748,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3791,6 +3875,109 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.0.0.tgz",
+      "integrity": "sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.6",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
@@ -6589,7 +6776,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6642,6 +6828,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -6836,7 +7027,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -6862,6 +7052,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-each-series": {
@@ -7220,6 +7418,18 @@
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -7253,6 +7463,23 @@
         "node": "6.* || >= 7.*"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7271,8 +7498,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sane": {
       "version": "4.1.0",
@@ -7449,8 +7675,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7861,6 +8086,22 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -7954,6 +8195,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -7985,9 +8232,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.8.0-dev.20220731",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220731.tgz",
+      "integrity": "sha512-RMnAFXQvFPMG1nOvMfnO0z1FvxKvH001GmBY14fXmX0DftaJvh4Huw8z/VWQF4IhWRSQr1tYo1+jwM2z6M/tZQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9455,6 +9702,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/diff": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.2.tgz",
+      "integrity": "sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -9462,6 +9715,16 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/inquirer": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.1.tgz",
+      "integrity": "sha512-wKW3SKIUMmltbykg4I5JzCVzUhkuD9trD6efAmYgN2MrSntY0SMRQzEnD3mkyJ/rv9NLbTC7g3hKKE86YwEDLw==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -9530,6 +9793,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -9606,7 +9878,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
       },
@@ -9614,8 +9885,7 @@
         "type-fest": {
           "version": "0.21.3",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-          "dev": true
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
         }
       }
     },
@@ -10022,14 +10292,6 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        }
       }
     },
     "char-regex": {
@@ -10037,6 +10299,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -10072,6 +10339,19 @@
           }
         }
       }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -10317,6 +10597,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -10620,6 +10905,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+    },
     "escodegen": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
@@ -10803,6 +11093,16 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -10887,6 +11187,14 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "fill-range": {
@@ -11149,7 +11457,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -11246,6 +11553,84 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.0.0.tgz",
+      "integrity": "sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.6",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -13357,8 +13742,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -13401,6 +13785,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13560,7 +13949,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -13578,6 +13966,11 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -13840,6 +14233,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -13861,6 +14263,20 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
+    "rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -13879,8 +14295,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -14018,8 +14433,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -14349,6 +14763,19 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -14423,6 +14850,12 @@
         "punycode": "^2.1.1"
       }
     },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -14448,9 +14881,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+      "version": "4.8.0-dev.20220731",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220731.tgz",
+      "integrity": "sha512-RMnAFXQvFPMG1nOvMfnO0z1FvxKvH001GmBY14fXmX0DftaJvh4Huw8z/VWQF4IhWRSQr1tYo1+jwM2z6M/tZQ=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
   },
   "dependencies": {
     "diff": "^5.1.0",
+    "git-status": "^1.0.10",
     "import-cwd": "^3.0.0",
     "inquirer": "^8.0.0",
     "lodash": "^4.17.21",
-    "typescript": "4.8.0-dev.20220731",
+    "typescript": "4.9.0-dev.20220812",
     "yargs": "^16.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "name": "ts-fix",
   "author": "Isabel Duan",
   "devDependencies": {
+    "@types/diff": "^5.0.2",
+    "@types/inquirer": "^8.2.1",
     "@types/jest": "^26.0.24",
     "@types/jest-specific-snapshot": "^0.5.5",
     "@types/lodash": "^4.14.171",
@@ -30,9 +32,11 @@
     "jest-specific-snapshot": "^5.0.0"
   },
   "dependencies": {
+    "diff": "^5.1.0",
     "import-cwd": "^3.0.0",
+    "inquirer": "^8.0.0",
     "lodash": "^4.17.21",
-    "typescript": "^4.3.5",
+    "typescript": "4.8.0-dev.20220731",
     "yargs": "^16.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "import-cwd": "^3.0.0",
     "inquirer": "^8.0.0",
     "lodash": "^4.17.21",
-    "typescript": "4.9.0-dev.20220812",
+    "typescript": "4.9.0-dev.20220816",
     "yargs": "^16.2.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,6 @@ export function makeOptions(cwd: string, args: string[]): Options {
     const {
         errorCode,
         file,
-        fix,
         fixName,
         ignoreGitStatus,
         interactiveMode,
@@ -31,11 +30,6 @@ export function makeOptions(cwd: string, args: string[]): Options {
             type: "string",
             array: true,
             default: []
-        })
-        .option("fix", {
-            describe: "Tool will only automatically attempt to fix all issues that do not require human interaction if --fix is included. It requires the --write flag to modify the files",
-            type: "boolean",
-            default: false
         })
         .option("fixName", {
             alias: "f",
@@ -85,7 +79,6 @@ export function makeOptions(cwd: string, args: string[]): Options {
         cwd,
         errorCode,
         file,
-        fix,
         fixName,
         ignoreGitStatus,
         interactiveMode,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,8 @@ export function makeOptions(cwd: string, args: string[]): Options {
         fixName,
         verbose,
         write,
+        fix,
+        interactiveMode
     } = yargs(args)
             .scriptName("ts-fix")
             .usage("$0 -t path/to/tsconfig.json -f nameOfCodefix")
@@ -27,7 +29,7 @@ export function makeOptions(cwd: string, args: string[]): Options {
                 }
             })
             // .option("file", {
-            //     description: "files to codefix. Not implemented yet.",
+            //     description: "files to codefix. Not implemented yet.", //TODOFIX
             //     type: "string"
             // })
             .option("errorCode", {
@@ -35,7 +37,7 @@ export function makeOptions(cwd: string, args: string[]): Options {
                 describe: "The error code(s)",
                 type: "number",
                 array: true,
-                default: [],
+                default: []
             })
             .option("fixName", {
                 alias: "f",
@@ -48,7 +50,7 @@ export function makeOptions(cwd: string, args: string[]): Options {
                alias: "w", 
                describe: "Tool will only emit or overwrite files if --write is included.",
                type:"boolean", 
-               default: false,
+               default: false
            })
            .option("outputFolder", {
                 alias: "o", 
@@ -58,18 +60,32 @@ export function makeOptions(cwd: string, args: string[]): Options {
             .option("verbose", {
                 describe: "Write status to console during runtime",
                 type: "boolean",
-                default: true,
+                default: true
+            })
+            .option("fix",{
+                describe: "Tool will only automatically attempts to fix all issues that do not require human interaction if --fix is included",
+                type: "boolean",
+                default: false
+            })
+            .option("interactiveMode",{ //TODOFIX
+                alias: "im",
+                describe: "Creates patch file allowing the user to decide which fix to apply",
+                type: "boolean",
+                default: false
             })
             .argv;
-    
+
     return {
         cwd,
         tsconfig,
         errorCode,
         fixName,
         write,
-        verbose, // TODO, not sure if this does anything after redoing CLIHost
-        outputFolder: outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig)
+        verbose, // TODO, not sure if this does anything after redoing CLIHost TODOFIX
+        outputFolder: 
+         outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig),
+        fix,
+        interactiveMode
     };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ export function makeOptions(cwd: string, args: string[]): Options {
         write,
     } = yargs(args)
         .scriptName("ts-fix")
-        .usage("$0 -t path/to/tsconfig.json -f nameOfCodefix")
+        .usage("$0 -t path/to/tsconfig.json")
         .option("errorCode", {
             alias: "e",
             describe: "The error code(s)",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import yargs from 'yargs';
 import path from "path";
 import { Options, codefixProject, CLIHost } from '.';
@@ -14,65 +13,68 @@ export function makeOptions(cwd: string, args: string[]): Options {
         verbose,
         write,
         fix,
+        file,
         interactiveMode
     } = yargs(args)
-            .scriptName("ts-fix")
-            .usage("$0 -t path/to/tsconfig.json -f nameOfCodefix")
-            .option("tsconfig", {
-                alias: "t",
-                description: "Path to project's tsconfig",
-                type: "string",
-                nargs: 1,
-                default: "./tsconfig.json",
-                coerce: (arg: string) => {
-                    return path.resolve(cwd, arg);
-                }
-            })
-            // .option("file", {
-            //     description: "files to codefix. Not implemented yet.", //TODOFIX
-            //     type: "string"
-            // })
-            .option("errorCode", {
-                alias: "e",
-                describe: "The error code(s)",
-                type: "number",
-                array: true,
-                default: []
-            })
-            .option("fixName", {
-                alias: "f",
-                describe: "The name(s) of codefixe(s) to apply",
-                type: "string",
-                array: true, 
-                default: []
-            }) 
-           .option("write", {
-               alias: "w", 
-               describe: "Tool will only emit or overwrite files if --write is included.",
-               type:"boolean", 
-               default: false
-           })
-           .option("outputFolder", {
-                alias: "o", 
-                describe: "Path of output directory",
-                type: "string"
-            })
-            .option("verbose", {
-                describe: "Write status to console during runtime",
-                type: "boolean",
-                default: true
-            })
-            .option("fix",{
-                describe: "Tool will only automatically attempts to fix all issues that do not require human interaction if --fix is included",
-                type: "boolean",
-                default: false
-            })
-            .option("interactiveMode",{ //TODOFIX
-                alias: "im",
-                describe: "Creates patch file allowing the user to decide which fix to apply",
-                type: "boolean",
-                default: false
-            })
+        .scriptName("ts-fix")
+        .usage("$0 -t path/to/tsconfig.json -f nameOfCodefix")
+        .option("tsconfig", {
+            alias: "t",
+            description: "Path to project's tsconfig",
+            type: "string",
+            nargs: 1,
+            default: "./tsconfig.json",
+            coerce: (arg: string) => {
+                return path.resolve(cwd, arg);
+            }
+        })
+        .option("file", {
+            description: "Relative paths of file(s) in which to apply code fixes",
+            type: "string",
+            array: true,
+            default: []
+        })
+        .option("errorCode", {
+            alias: "e",
+            describe: "The error code(s)",
+            type: "number",
+            array: true,
+            default: []
+        })
+        .option("fixName", {
+            alias: "f",
+            describe: "The name(s) of codefixe(s) to apply",
+            type: "string",
+            array: true,
+            default: []
+        })
+        .option("write", {
+            alias: "w",
+            describe: "Tool will only emit or overwrite files if --write is included.",
+            type: "boolean",
+            default: false
+        })
+        .option("outputFolder", {
+            alias: "o",
+            describe: "Path of output directory",
+            type: "string"
+        })
+        .option("verbose", {
+            describe: "Write status to console during runtime",
+            type: "boolean",
+            default: true
+        })
+        .option("fix", {
+            describe: "Tool will only automatically attempts to fix all issues that do not require human interaction if --fix is included",
+            type: "boolean",
+            default: false
+        })
+        .option("interactiveMode", { //TODOFIX
+            alias: "im",
+            describe: "Creates patch file allowing the user to decide which fix to apply",
+            type: "boolean",
+            default: false
+        })
             .argv;
 
     return {
@@ -82,9 +84,9 @@ export function makeOptions(cwd: string, args: string[]): Options {
         fixName,
         write,
         verbose, // TODO, not sure if this does anything after redoing CLIHost TODOFIX
-        outputFolder: 
-         outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig),
+        outputFolder: outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig),
         fix,
+        file,
         interactiveMode
     };
 }
@@ -92,10 +94,10 @@ export function makeOptions(cwd: string, args: string[]): Options {
 if (!module.parent) {
     const opt = makeOptions(process.cwd(), process.argv.slice(2));
     let host = new CLIHost(process.cwd());
-    (async() => { 
+    (async () => {
         const error = await codefixProject(opt, host);
         host.log(error);
     })();
-        // error is a string if codefixProject did an error
+    // error is a string if codefixProject did an error
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,18 +6,64 @@ import { Options, codefixProject, CLIHost } from '.';
 
 export function makeOptions(cwd: string, args: string[]): Options {
     const {
-        tsconfig,
-        outputFolder,
         errorCode,
-        fixName,
-        verbose,
-        write,
-        fix,
         file,
-        interactiveMode
+        fix,
+        fixName,
+        ignoreGitStatus,
+        interactiveMode,
+        outputFolder,
+        showMultiple,
+        tsconfig,
+        write,
     } = yargs(args)
         .scriptName("ts-fix")
         .usage("$0 -t path/to/tsconfig.json -f nameOfCodefix")
+        .option("errorCode", {
+            alias: "e",
+            describe: "The error code(s)",
+            type: "number",
+            array: true,
+            default: []
+        })
+        .option("file", {
+            description: "Relative paths to the file(s) for which to find diagnostics",
+            type: "string",
+            array: true,
+            default: []
+        })
+        .option("fix", {
+            describe: "Tool will only automatically attempt to fix all issues that do not require human interaction if --fix is included. It requires the --write flag to modify the files",
+            type: "boolean",
+            default: false
+        })
+        .option("fixName", {
+            alias: "f",
+            describe: "The name(s) of codefixe(s) to apply",
+            type: "string",
+            array: true,
+            default: []
+        })
+        .option("ignoreGitStatus", {
+            describe: "Must use if the git status isn't clean, the write flag is being used, and the output folder is the same as the project folder",
+            type: "boolean",
+            default: false
+        })
+        .option("interactiveMode", {
+            describe: "Takes input from the user to decide which fixes to apply",
+            type: "boolean",
+            default: false
+        })
+        .option("outputFolder", {
+            alias: "o",
+            describe: "Path of output directory",
+            type: "string"
+        })
+        .option("showMultiple", {
+            describe: "Takes input from the user to decide which fix to apply when there are more than one quick fix for a diagnostic, if this flag is not provided the tool will apply the first fix found for the diagnostic",
+            type: "boolean",
+            default: false
+        })
         .option("tsconfig", {
             alias: "t",
             description: "Path to project's tsconfig",
@@ -28,66 +74,25 @@ export function makeOptions(cwd: string, args: string[]): Options {
                 return path.resolve(cwd, arg);
             }
         })
-        .option("file", {
-            description: "Relative paths of file(s) in which to apply code fixes",
-            type: "string",
-            array: true,
-            default: []
-        })
-        .option("errorCode", {
-            alias: "e",
-            describe: "The error code(s)",
-            type: "number",
-            array: true,
-            default: []
-        })
-        .option("fixName", {
-            alias: "f",
-            describe: "The name(s) of codefixe(s) to apply",
-            type: "string",
-            array: true,
-            default: []
-        })
         .option("write", {
             alias: "w",
             describe: "Tool will only emit or overwrite files if --write is included.",
             type: "boolean",
             default: false
         })
-        .option("outputFolder", {
-            alias: "o",
-            describe: "Path of output directory",
-            type: "string"
-        })
-        .option("verbose", {
-            describe: "Write status to console during runtime",
-            type: "boolean",
-            default: true
-        })
-        .option("fix", {
-            describe: "Tool will only automatically attempts to fix all issues that do not require human interaction if --fix is included",
-            type: "boolean",
-            default: false
-        })
-        .option("interactiveMode", { //TODOFIX
-            alias: "im",
-            describe: "Creates patch file allowing the user to decide which fix to apply",
-            type: "boolean",
-            default: false
-        })
-            .argv;
-
+        .argv;
     return {
         cwd,
-        tsconfig,
         errorCode,
-        fixName,
-        write,
-        verbose, // TODO, not sure if this does anything after redoing CLIHost TODOFIX
-        outputFolder: outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig),
-        fix,
         file,
-        interactiveMode
+        fix,
+        fixName,
+        ignoreGitStatus,
+        interactiveMode,
+        outputFolder : outputFolder ? path.resolve(cwd, outputFolder) : path.dirname(tsconfig),
+        showMultiple,
+        tsconfig,
+        write,
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 import path from "path";
-import { CodeFixAction, Diagnostic, FileTextChanges, formatDiagnosticsWithColorAndContext, TextChange } from "typescript";
+import { CodeFixAction, Diagnostic, DiagnosticCategory, FileTextChanges, formatDiagnosticsWithColorAndContext, SourceFile, TextChange } from "typescript";
 import os from "os";
-import _, { flatMap } from "lodash";
+import _, { flatMap, cloneDeep, isEqual } from "lodash";
 import { createProject, Project } from "./ts";
 import * as fs from "fs";
 import { diffChars } from "diff";
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
+import { formatDiagnosticsWithColorAndContextTsFix, formatFixOnADifferentLocation } from "./utilities";
+import { exec } from 'child_process';
+import { option } from "yargs";
 
 export interface Logger {
   (...args: any[]): void;
@@ -73,7 +76,9 @@ export class CLIHost implements Host {
   exists(fileName: fs.PathLike) { return fs.existsSync(fileName) };
 
   getNewLine() { return "\n" }
+
   getCurrentDirectory() { return process.cwd() }
+
   getCanonicalFileName(fileName: string) { return fileName.toLowerCase() }
 }
 
@@ -82,31 +87,48 @@ export interface Options {
   tsconfig: string;
   outputFolder: string;
   errorCode: number[];
-  // file: string;
   file: string[];
   fixName: string[];
   write: boolean,
-  verbose: boolean,
   fix: boolean,
+  showMultiple: boolean,
   interactiveMode: boolean,
+  ignoreGitStatus: boolean
 }
 
-const isAdditionalPassRequired = (opt: Options, passCount: number): boolean => {
-  let isAdditionalPassRequired = true;
-  let totalPossiblePassCount = 2; //For when -f or -e are provided
-  if (opt.errorCode.length && opt.fixName.length && passCount === totalPossiblePassCount) { //&& !opt.interactiveMode TODOFIX, it might not be needed 2 runs for interactive mode seem enough
-    isAdditionalPassRequired = false;
+const gitStatus = (dir: string) => new Promise<string>((resolve) => {
+  const dirPath = path.dirname(dir);
+  return exec(`git --git-dir="${dirPath + "\\.git"}" --work-tree="${dirPath}" status --porcelain`, (err, stdout) => {
+    if (err) throw new Error(err.message);
+    else if (typeof stdout === 'string') resolve(stdout.trim());
+  });
+});
+
+const checkOptions = async (opt: Options): Promise<[string[], string[]]> => {
+
+  if (!fs.existsSync(opt.tsconfig)) {
+    throw new Error(`The tsconfig file doesn't exist on the path provided`);
   }
-  return isAdditionalPassRequired;
-}
 
-export async function codefixProject(opt: Options, host: Host): Promise<string> {
+  //Check git status if the write flag was provided and the output folder is the same as the project folder. Do not allow the overwrite of files with previous changes on them unless --ignoreGitStatus flag was provided
+  if (opt.write && path.dirname(opt.tsconfig) === opt.outputFolder) {
+    let isModified = false;
+    const status = await (gitStatus(opt.tsconfig));
+    const splitStatus = status.split(/\r?\n/);
+    if (splitStatus.length && splitStatus[0] != '') {
+      const re = /[MARCD?]\s(package).+?(json)/g
+      isModified = splitStatus.length && splitStatus[0] !== '' ? !(splitStatus.filter((text) => { return text.match(re) }).length === splitStatus.length) : false;
+    }
+    if (isModified && !opt.ignoreGitStatus) {
+      throw new Error(`Please provide the --ignoreGitStatus flag if you are sure you'ld like to override your exisiting changes`);
+    }
+  }
 
   let validFiles = new Array<string>;
   let invalidFiles = new Array<string>;
-  if (opt.file) {
+  if (opt.file.length) {
     opt.file.forEach((file) => {
-      file = path.join(path.dirname(opt.tsconfig), file)
+      file = path.join(path.dirname(opt.tsconfig), file);
       if (fs.existsSync(file)) {
         validFiles.push(file);
       }
@@ -114,23 +136,60 @@ export async function codefixProject(opt: Options, host: Host): Promise<string> 
         invalidFiles.push(file);
       }
     });
-    if (validFiles.length === 0) {
+    if (!validFiles.length) {
       throw new Error(`All provided files are invalid`);
     }
   }
+  return [validFiles, invalidFiles];
+}
 
-  if (opt.errorCode.length === 0 && opt.fixName.length === 0) {
-    host.log("Please be aware that not specifying either code fix names or error codes often results in unwanted changes.");
+//TODOFIX - Keep this or remove?
+enum starterText {
+  'Give us a second to find your diagnostics' = 1,
+  'We are creating the project please be patient' = 2,
+  'Hold tight, we are finding your diagnostics' = 3,
+}
+
+function printSummary(host: Host, opt: Options, invalidFiles: string[], allChangedFiles: Map<string, ChangedFile>, pendingChangesByFile: Map<string, TextChange[]>): void {
+  if (invalidFiles.length || pendingChangesByFile.size || opt.write) host.log("Summary: ")
+  if (invalidFiles.length) {
+    host.log("The following file paths are invalid:")
+    invalidFiles.forEach((file) => host.log(file));
   }
+  if (pendingChangesByFile.size) {
+    host.log("There are some pending changes. This usually means you'll need to install missing dependencies. See details below:");
+    pendingChangesByFile.forEach((change, fileName) => {
+      host.log(`${change} ${fileName}`);
+    })
+  }
+  if (opt.write) {
+    const allChangedFilesSize = allChangedFiles.size;
+    if (allChangedFilesSize === 0) host.log("No changes made in any files")
+    if (allChangedFilesSize === 1) host.log("Changes were made in the following file:")
+    else if (allChangedFilesSize > 1) {
+      host.log("Changes were made in the following files:");
+    }
+    allChangedFiles.forEach((changedFile, fileName) => {
+      writeToFile(fileName, changedFile.newText, opt, host);
+    })
+  }
+}
+
+export async function codefixProject(opt: Options, host: Host): Promise<string> {
+
+  const [validFiles, invalidFiles] = await checkOptions(opt);
 
   const allChangedFiles = new Map<string, ChangedFile>();
+  let allPendingChangesByFile = new Map<string, TextChange[]>; //TODOFIX - Use pendingChangesByFile in summary
   let passCount = 0;
 
-  while (isAdditionalPassRequired(opt, passCount)) {
+  while (true) {
+
+    if (passCount === 0) host.log("The project is being created...");
+    // if (passCount === 0) host.log(starterText[Math.ceil(Math.random() * (3 - 0) + 0)]);
+
     const project = createProject({ tsConfigFilePath: opt.tsconfig }, allChangedFiles);
-    if (!project) {
-      return "Error: Could not create project.";
-    }
+    if (!project) return "Error: Could not create project.";
 
     if (passCount === 0) host.log("Using TypeScript " + project.ts.version);
 
@@ -142,49 +201,53 @@ export async function codefixProject(opt: Options, host: Host): Promise<string> 
     host.addRemainingChanges(excessChanges);
 
     if (hasOnlyEmptyLists(excessChanges)) {
-      host.log("No changes remaining for ts-fix. Printing summary... \n");
-      if (pendingChangesByFile.size) {
-        host.log("There are some pending changes. This usually means you'll need to install missing dependencies. See below:");
-        pendingChangesByFile.forEach((change, fileName) => {
-          host.log(`${change} ${fileName}`);
-        })
-      }
+      host.log("No changes remaining for ts-fix\n");
       break;
     } else {
-      host.log(excessChanges.size + " changes remaining. Initiating additional pass...\n");
+      host.log(excessChanges.size + " changes remaining. Initiating additional pass...\n"); //TODOFIX - Take a look at this, the count is a little misleading
     }
 
     passCount++;
   }
 
-  if (opt.write) {
-    if (allChangedFiles.size === 0) host.log("No changes made in any files")
-    if (allChangedFiles.size === 1) host.log("Changes were made in the following file:")
-    else if (allChangedFiles.size > 1) {
-      host.log("Changes were made in the following files:");
-    }
-    allChangedFiles.forEach((changedFile, fileName) => {
-      writeToFile(fileName, changedFile.newText, opt, host);
-    })
-  }
+  printSummary(host, opt, invalidFiles, allChangedFiles, allPendingChangesByFile);
 
   return "Done";
+}
+
+//TODOFIX - Missing additional conditions
+// Finds the fixes that don't make any changes (install module), and out of scope of the use case such as import, fixMissingFunctionDeclaration
+function isNoAppliedFix(fixAndDiagnostic: FixAndDiagnostic): boolean {
+  return !fixAndDiagnostic.fix.changes.length
+    || fixAndDiagnostic.fix.fixName === 'import'
+    || fixAndDiagnostic.fix.fixName === 'fixMissingFunctionDeclaration'
+  // && codefix.fixName !== "fixMissingMember"); TODOFIX - I probably wont need this once issue 49993 is fixed
+}
+
+
+function getAppliedAndNoAppliedFixes(flatCodeFixesAndDiagnostics: FixAndDiagnostic[]): [FixAndDiagnostic[], CodeFixAction[]] {
+  let fixesAndDiagnostics: FixAndDiagnostic[] = [];
+  let noAppliedFixes: CodeFixAction[] = [];
+  flatCodeFixesAndDiagnostics.forEach((fixAndDiagnostic) => {
+    if (isNoAppliedFix(fixAndDiagnostic)) noAppliedFixes.push(fixAndDiagnostic.fix);
+    else fixesAndDiagnostics.push(fixAndDiagnostic);
+  })
+  return [fixesAndDiagnostics, noAppliedFixes]
 }
 
 export async function getCodeFixesFromProject(project: Project, opt: Options, host: Host, validFiles: string[]): Promise<[Map<string, TextChange[]>, Map<string, TextChange[]>]> {
 
   // pull all codefixes.
-  const diagnosticsPerFile = await getDiagnostics(project);
+  const diagnosticsPerFile = getDiagnostics(project);
 
-  if (diagnosticsPerFile.length === 0) {
+  if (!diagnosticsPerFile.length) {
     host.log("No more diagnostics.");
     return [new Map<string, TextChange[]>(), new Map<string, TextChange[]>]
   }
 
   // pull codefixes from diagnostics.  If errorCode is specified, only pull fixes for that/those errors. If file is specified, only pull fixes for that/those files.
   //    Otherwise, pull all fixes
-  let [filteredDiagnostics, acceptedDiagnosticsOut] = filterDiagnosticsByErrorCode(diagnosticsPerFile, opt.errorCode, validFiles);
-
+  let [filteredDiagnostics, acceptedDiagnosticsOut] = filterDiagnosticsByErrorCode(diagnosticsPerFile, opt.errorCode, validFiles); //TODOFIX - Instead of finding noAppliedFixes later, diagnostics codes that are out could be removed here, is that an option?
   acceptedDiagnosticsOut.forEach((string_describe: unknown) => {
     host.log(string_describe);
   });
@@ -192,24 +255,26 @@ export async function getCodeFixesFromProject(project: Project, opt: Options, ho
   let codefixesPerFile;
   let codefixes: readonly CodeFixAction[] = [];
   let fixesAndDiagnostics: FixAndDiagnostic[] = [];
+  let fixesAndDiagnosticsLength = 0;
   let updatedCodeFixes: CodeFixAction[] = [];
-  let noChangesFixes: CodeFixAction[] = [];
+  let noAppliedFixes: CodeFixAction[] = [];
 
+  //TODOFIX - Rework this so that the function doesn't contain this if/else
   if (opt.interactiveMode) {
     codefixesPerFile = filteredDiagnostics.map(function (d: readonly Diagnostic[]) {
       const fixesAndDiagnostics = (getCodeFixesForFileInteractive(project, d))
       return fixesAndDiagnostics;
     });
     const flatCodeFixesAndDiagnostics = <FixAndDiagnostic[]>_.flatten(codefixesPerFile);
-    fixesAndDiagnostics = flatCodeFixesAndDiagnostics.filter((fixAndDiagnostic) => fixAndDiagnostic.fix.changes.length > 0);
-     // && codefix.fixName !== "fixMissingMember"); TODOFIX I probably wont need this once 49993 it's fixed
-    noChangesFixes = flatCodeFixesAndDiagnostics.filter((fixAndDiagnostic) => fixAndDiagnostic.fix.changes.length === 0).map((fixAndDiagnostic) => { return fixAndDiagnostic.fix });
-    for (let i = 0; i < fixesAndDiagnostics.length; i++) {
-      let accepted = await getFileFixes(project, host, fixesAndDiagnostics[i]);
-      if (accepted) {
-        updatedCodeFixes.push(fixesAndDiagnostics[i].fix);
-      }
+    [fixesAndDiagnostics, noAppliedFixes] = getAppliedAndNoAppliedFixes(flatCodeFixesAndDiagnostics);
+
+    if (!opt.showMultiple) {
+      fixesAndDiagnostics = removeMutilpleDiagnostics(fixesAndDiagnostics);
     }
+
+    fixesAndDiagnostics = removeDuplicatedFixes(fixesAndDiagnostics);
+    fixesAndDiagnosticsLength = fixesAndDiagnostics.length;
+    updatedCodeFixes = await getFileFixes(project, host, opt, fixesAndDiagnostics);
   }
   else {
     codefixesPerFile = filteredDiagnostics.map(function (d: readonly Diagnostic[]) {
@@ -217,98 +282,100 @@ export async function getCodeFixesFromProject(project: Project, opt: Options, ho
       return codefixes;
     });
     const flatCodeFixes = <CodeFixAction[]>_.flatten(codefixesPerFile);
-    codefixes = flatCodeFixes.filter((codefix) => codefix.changes.length > 0);
-    noChangesFixes = flatCodeFixes.filter((codefix) => codefix.changes.length === 0);
+    codefixes = flatCodeFixes.filter((codefix) => codefix.changes.length);
+    noAppliedFixes = flatCodeFixes.filter((codefix) => !codefix.changes.length);
   }
 
   // filter for codefixes if applicable, then organize textChanges by what file they alter
-  const [textChangesByFile, filterCodefixOut] = opt.interactiveMode ? getTextChangeDict(opt, updatedCodeFixes, fixesAndDiagnostics.length) : getTextChangeDict(opt, codefixes);
-  const [pendingChangesByFile, filterCodefixOut1] = getTextChangeDict(opt, noChangesFixes); //TODOFIX use this for summary
-
-  filterCodefixOut.forEach((s: unknown) => {
-    host.log(s);
-  });
+  const [textChangesByFile, filterCodefixOut] = opt.interactiveMode ? getTextChangeDict(opt, updatedCodeFixes, fixesAndDiagnosticsLength) : getTextChangeDict(opt, codefixes);
+  const [pendingChangesByFile, filterCodefixOutNoChangeFixes] = getTextChangeDict(opt, noAppliedFixes);
+  filterCodefixOut.forEach((s: string) => { host.log(s); });
 
   return [textChangesByFile, pendingChangesByFile];
 }
 
 export function getDiagnostics(project: Project): (readonly Diagnostic[])[] {
-  const diagnostics = project.program.getSourceFiles().map(function (file) {
+  const diagnostics = project.program.getSourceFiles().map(function (file: SourceFile) {
     return project.program.getSemanticDiagnostics(file);
   });
   return diagnostics;
 }
 
+
 export function filterDiagnosticsByErrorCode(diagnostics: (readonly Diagnostic[])[], errorCodes: number[], validFiles?: string[]): [(readonly Diagnostic[])[], string[]] {
   // if errorCodes were passed in, only use the specified errors
-  // diagnostics is guarenteed to not be [] or [[]]
-  if (errorCodes.length !== 0) {
+  // diagnostics is guaranteed to not be [] or [[]]
+  let returnStrings = <string[]>[];
+  if (errorCodes.length || validFiles?.length) {
+    if (validFiles?.length) {
+      let length = 0;
+      const filteredDiagnostics = diagnostics.filter((diagnostics) => diagnostics.length);
+      let returnDiagnostics = new Array<Diagnostic[]>;
 
-    let errorCounter = new Map<number, number>();
-    let filteredDiagnostics = <(readonly Diagnostic[])[]>[];
-
-    for (let i = 0; i < diagnostics.length; i++) {
-      //for every diagnostic list
-      // get rid of not matched errors
-      const filteredDiagnostic = _.filter(diagnostics[i], function (d) {
-        if (errorCodes.includes(d.code)) {
-          const currentVal = errorCounter.get(d.code);
-          if (currentVal !== undefined) {
-            errorCounter.set(d.code, currentVal + 1);
-          } else {
-            errorCounter.set(d.code, 1);
+      for (let i = 0; i < filteredDiagnostics.length; i++) {
+        let index = 0;
+        returnDiagnostics[i] = new Array<Diagnostic>;
+        filteredDiagnostics[i].filter((diagnostic) => { //TODOFIX - Each filteredDiagnostics array corresponds to a single file so this can be improved
+          if (diagnostic.file && validFiles) {
+            if (validFiles.indexOf(path.normalize(diagnostic.file?.fileName)) != -1) {
+              returnDiagnostics[i][index] = diagnostic;
+              index++;
+              length++;
+            }
           }
-          return true;
-        }
-        return false;
-      });
-      if (filteredDiagnostic.length > 0) {
-        filteredDiagnostics.push(filteredDiagnostic);
+        });
       }
+      returnDiagnostics = returnDiagnostics.filter((diagnostics) => diagnostics.length);
+      diagnostics = returnDiagnostics;
+
+      if (length === 0) returnStrings.push(`No diagnostics founds for files`);
+      else returnStrings.push(`Found ${length} diagnostics for given files`);
     }
 
-    let returnStrings = <string[]>[];
-    errorCodes.forEach((code: number) => {
-      const count = errorCounter.get(code);
-      if (count === undefined) {
-        returnStrings.push("No diagnostics found with code " + code)
-      } else {
-        returnStrings.push("Found " + count + " diagnostics with code " + code);
-      }
-    });
 
-    return [filteredDiagnostics, returnStrings];
-  }
-  else if (validFiles) {
-    let length = 0;
-    const filteredDiagnostics = diagnostics.filter((diagnostics) => diagnostics.length > 0);
-    let returnDiagnostics = new Array<Diagnostic[]>;
+    if (errorCodes.length) {
+      let errorCounter = new Map<number, number>();
+      let filteredDiagnostics = <(readonly Diagnostic[])[]>[];
 
-    for (let i = 0; i < filteredDiagnostics.length; i++) {
-      let index = 0;
-      returnDiagnostics[i] = new Array<Diagnostic>;
-      filteredDiagnostics[i].filter((diagnostic) => { //TODOFIX each array belongs to a file so this can be improved
-        if (diagnostic.file) {
-          if (validFiles.indexOf(path.normalize(diagnostic.file?.fileName)) != -1) {
-            returnDiagnostics[i][index] = diagnostic;
-            index++;
-            length++;
+      for (let i = 0; i < diagnostics.length; i++) {
+        //for every diagnostic list
+        // get rid of not matched errors
+        const filteredDiagnostic = _.filter(diagnostics[i], function (d) {
+          if (errorCodes.includes(d.code)) {
+            const currentVal = errorCounter.get(d.code);
+            if (currentVal !== undefined) {
+              errorCounter.set(d.code, currentVal + 1);
+            } else {
+              errorCounter.set(d.code, 1);
+            }
+            return true;
           }
+          return false;
+        });
+        if (filteredDiagnostic.length) {
+          filteredDiagnostics.push(filteredDiagnostic);
+        }
+      }
+
+      errorCodes.forEach((code: number) => {
+        const count = errorCounter.get(code);
+        if (count === undefined) {
+          returnStrings.push(`No diagnostics found with code ${code}`);
+        } else {
+          returnStrings.push(`Found ${count} diagnostics with code ${code}`);
         }
       });
+
+      diagnostics = filteredDiagnostics;
     }
-    returnDiagnostics = returnDiagnostics.filter((diagnostics) => diagnostics.length > 0);
 
-    let returnStrings = <string[]>[];
-    if (length === 0) returnStrings.push(`No diagnostics founds for files`);
-    else returnStrings.push(`Found ${length} diagnostics for given files`);
-
-    return [returnDiagnostics, returnStrings]
+    return [diagnostics, returnStrings]
   }
+
   // otherwise, use all errors
-  return [diagnostics, ["Found " + _.reduce(diagnostics.map((d: { length: any; }) => d.length), function (sum, n) {
+  else return [diagnostics.filter((diagnostic) => diagnostic.length), [`Found ${_.reduce(diagnostics.map((d: { length: any; }) => d.length), function (sum, n) {
     return sum + n;
-  }, 0) + " diagnostics in " + diagnostics.length + " files"]];
+  }, 0)} diagnostics in ${diagnostics.length} files`]];
 }
 
 interface FixAndDiagnostic {
@@ -327,7 +394,7 @@ export function getCodeFixesForFile(project: Project, diagnostics: readonly Diag
         d.start + d.length,
         [d.code],
         project.ts.getDefaultFormatCodeSettings(os.EOL),
-        {}).map((fix) => {
+        {}).map((fix: CodeFixAction) => {
           return fix;
         });
     } else {
@@ -340,14 +407,14 @@ export function getCodeFixesForFileInteractive(project: Project, diagnostics: re
   // expects already filtered diagnostics
   const service = project.languageService;
   return flatMap(diagnostics, d => {
-    if (d.file && d.start !== undefined && d.length !== undefined) {
+    if (d.file && d.start && d.length) {
       return service.getCodeFixesAtPosition(
         d.file.fileName,
         d.start,
         d.start + d.length,
         [d.code],
         project.ts.getDefaultFormatCodeSettings(os.EOL),
-        {}).map((fix) => {
+        {}).map((fix: CodeFixAction) => {
           return { fix, diagnostic: d };
         });
     } else {
@@ -389,48 +456,52 @@ export function getTextChangeDict(opt: Options, codefixes: readonly CodeFixActio
 }
 
 export function filterCodeFixesByFixName(codefixes: readonly CodeFixAction[], fixNames: string[], originalLength?: number): [readonly CodeFixAction[], string[]] {
-  if (fixNames.length === 0) {
+  if (!fixNames.length) {
     // empty argument behavior... currently, we just keep all fixes if none are specified
     let returnStrings = <string[]>[];
     let codeFixes = new Set<string>();
     let fixesNames = new Array<string>();
-    let fixesString = <string[]>[];
+    let fixesString: string[] = [];
+    let fixesFound = '';
     const appliedFixesLength = codefixes.length;
+    //TODOFIX - This count is off because of the fixes in the same line
     if (originalLength) {
-      if (appliedFixesLength === 0) { fixesString.push(`Found ${originalLength} codefixes but none were accepted by the user`) }
-      else if (appliedFixesLength === 1) { fixesString.push(`Found ${originalLength} codefixes but only 1 was accepted by the user`) }
-      else { fixesString.push(`Found ${originalLength} codefixes but only ${appliedFixesLength} were accepted by the user`) }
+      if (appliedFixesLength === 0) { returnStrings.push(`Found ${originalLength} codefixes and none were accepted by the user`); }
+      else if (appliedFixesLength === originalLength) { returnStrings.push(`Found ${originalLength} codefixes and all were accepted by user`); }
+      else if (appliedFixesLength === 1) { returnStrings.push(`Found ${originalLength} codefixes, 1 code fix was accepted by the user`); }
+      else { returnStrings.push(`Found ${originalLength} codefixes, ${appliedFixesLength} were accepted by the user`); }
     }
     if (!originalLength) {
-      fixesString.push(`Found ${codefixes.length} codefixes`)
+      fixesFound += `Found ${codefixes.length} codefixes`;
       codefixes.forEach((codeFix: CodeFixAction) => {
         if (codeFix.fixName !== undefined && !codeFixes.has(codeFix.fixName)) {
           codeFixes.add(codeFix.fixName);
           fixesNames.push(codeFix.fixName);
         }
       })
-      const fixesLength = fixesNames.length
+      const fixesLength = fixesNames.length;
       if (fixesLength === 1) {
-        fixesString.push(`. Fix ${fixesNames[0]} was found`);
+        fixesFound += `. Fix ${fixesNames[0]} was found`;
       }
       if (fixesLength >= 2) {
-        fixesString.push(`. The codefixes found are: `);
+        fixesFound += `. The codefixes found are: `;
         for (let i = 0; i < fixesLength; i++) {
-          fixesString.push(fixesNames[i]);
+          fixesFound += fixesNames[i];
           if (i !== fixesLength - 1) {
-            fixesString.push(`, `);
+            fixesFound += `, `;
           }
         }
       }
     }
-    return [codefixes, [fixesString.join('')]];
+    returnStrings.push(fixesFound);
+    return [codefixes, returnStrings];
   }
 
   // cannot sort by fixId right now since fixId is a {}
   // do we want to distinguish the case when no codefixes are picked? (no hits)
 
   let fixCounter = new Map<string, number>();
-  let out = <string[]>[];
+  let out: string[] = [];
   const filteredFixes = codefixes.filter(function (fix: { fixName: any; }) {
     if (fixNames.includes(fix.fixName)) {
       const currentVal = fixCounter.get(fix.fixName);
@@ -447,9 +518,9 @@ export function filterCodeFixesByFixName(codefixes: readonly CodeFixAction[], fi
   fixNames.forEach((name: string) => {
     const count = fixCounter.get(name);
     if (count === undefined) {
-      out.push("No codefixes found with name " + name)
+      out.push(`No codefixes found with name ${name}`);
     } else {
-      out.push("Found " + count + " codefixes with name " + name);
+      out.push(`Found ${count} codefixes with name ${name}`);
     }
   });
 
@@ -468,21 +539,298 @@ export interface ChangedFile {
   newText: string;
 }
 
-async function getFileFixes(project: Project, host: Host, codefix: FixAndDiagnostic): Promise<boolean> {
-  for (let i = 0; i < codefix.fix.changes.length; i++) {
-    const fileName = codefix.fix.changes[i].fileName
-    const sourceFile = project.program.getSourceFile(fileName);
-    if (sourceFile !== undefined) {
-      for (let j = 0; j < codefix.fix.changes[i].textChanges.length; j++) {
-        host.log(formatDiagnosticsWithColorAndContext([codefix.diagnostic], host));
-        const userDecision = await getInputFromUser(codefix.fix.fixName);
-        if (Choices.reject === userDecision) {
-          return false;
+async function getUpdatedCodeFixesAndDiagnostics(codeFixesAndDiagnostics: FixAndDiagnostic[], codefixes: CodeFixAction[], count: number, showMultiple?: boolean): Promise<[FixAndDiagnostic[], CodeFixAction[]]> {
+  const currentDiagnostic = codeFixesAndDiagnostics[0].diagnostic;
+  const currentCodeFix = codeFixesAndDiagnostics[0].fix;
+  const userInput = await getInputFromUser(codeFixesAndDiagnostics[0].fix, showMultiple);
+
+  if (userInput === Choices.ACCEPT) {
+    if (showMultiple) {
+      codefixes.push(currentCodeFix);
+      codeFixesAndDiagnostics = removeMutilpleDiagnostics(codeFixesAndDiagnostics, Choices.ACCEPT)
+    }
+    else {
+      codefixes.push(currentCodeFix);
+      codeFixesAndDiagnostics.splice(0, count);
+    };
+  }
+  else if (userInput === Choices.ACCEPTALL) {
+    if (showMultiple) {
+      codeFixesAndDiagnostics = removeMutilpleDiagnostics(codeFixesAndDiagnostics, Choices.ACCEPTALL);
+    }
+    let updatedFixesAndDiagnostics = codeFixesAndDiagnostics.filter((diagnosticAndFix) => diagnosticAndFix.diagnostic.code === currentDiagnostic.code);
+    updatedFixesAndDiagnostics.map((diagnosticAndFix) => {
+      return codefixes.push(diagnosticAndFix.fix);
+    });
+    codeFixesAndDiagnostics = codeFixesAndDiagnostics.filter((diagnosticAndFix) => diagnosticAndFix.diagnostic.code !== codeFixesAndDiagnostics[0].diagnostic.code);
+  }
+  else if (userInput === Choices.SKIPALL) {
+    let updatedFixesAndDiagnostics = codeFixesAndDiagnostics.filter((diagnosticAndFix) => diagnosticAndFix.diagnostic.code === currentDiagnostic.code);
+    updatedFixesAndDiagnostics.forEach(diagnosticAndFix => codeFixesAndDiagnostics.splice(codeFixesAndDiagnostics.findIndex(fixAndDiagnostic => fixAndDiagnostic.diagnostic.code === diagnosticAndFix.diagnostic.code), count))
+  }
+  else if (userInput === Choices.SKIP) {
+    codeFixesAndDiagnostics.splice(0, count);
+  }
+  else if (userInput === Choices.SHOWMULTIPLE) {
+    const chooseCodeFix = await getUserPick(codeFixesAndDiagnostics.slice(0, count))
+    //TODOFIX - Implement Back option
+    // if (chooseCodeFix === Choices.BACK) {}
+    if (codeFixesAndDiagnostics.filter((codeFixAndDiagnostic) => `"${codeFixAndDiagnostic.fix.fixName}" fix with description "${codeFixAndDiagnostic.fix.description}"` === chooseCodeFix).length) {
+      codefixes.push(codeFixesAndDiagnostics.filter((codeFixAndDiagnostic) => `"${codeFixAndDiagnostic.fix.fixName}" fix with description "${codeFixAndDiagnostic.fix.description}"` === chooseCodeFix)[0].fix);
+    }
+    codeFixesAndDiagnostics.splice(0, count);
+  }
+  return [codeFixesAndDiagnostics, codefixes];
+}
+
+
+async function getUserPick(currentFixesAndDiagnostics: FixAndDiagnostic[]): Promise<string> {
+  const choices = currentFixesAndDiagnostics.map((codeFixAndDiagnostic) => {
+    return `"${codeFixAndDiagnostic.fix.fixName}" fix with description "${codeFixAndDiagnostic.fix.description}"`
+  });
+  // choices.push(Choices.BACK);
+  const choice = await inquirer
+    .prompt([
+      {
+        name: "codeFix",
+        type: "list",
+        message: `Which fix would you like to apply?`,
+        choices: choices
+      },
+    ]);
+  return choice.codeFix;
+};
+
+export interface ChangeDiagnostic {
+  file?: SourceFile,
+  start?: number,
+  length?: number,
+}
+
+// TODOFIX - Should make DRY
+// Removes multiple code fixes for the diagnostic if the user accepts the first one
+// Removes mutliple code fixes if the user decides to accept all of that type
+// Removes additional code fixes if the user decides not to show multiple
+// It will always keep the first code fix returned for the diagnostic
+function removeMutilpleDiagnostics(codeFixesAndDiagnostics: FixAndDiagnostic[], choice?: Choices.ACCEPT | Choices.ACCEPTALL): FixAndDiagnostic[] {
+  if (choice === Choices.ACCEPT) {
+    for (let i = 1; i < codeFixesAndDiagnostics.length; i++) {
+      let count = 1;
+      if (codeFixesAndDiagnostics[0].diagnostic.code === codeFixesAndDiagnostics[i].diagnostic.code && codeFixesAndDiagnostics[0].diagnostic.length === codeFixesAndDiagnostics[i].diagnostic.length && codeFixesAndDiagnostics[0].diagnostic.start === codeFixesAndDiagnostics[i].diagnostic.start) {
+        let j = i;
+        while (codeFixesAndDiagnostics[j] && codeFixesAndDiagnostics[0].diagnostic.code === codeFixesAndDiagnostics[j].diagnostic.code && codeFixesAndDiagnostics[0].diagnostic.length === codeFixesAndDiagnostics[j].diagnostic.length && codeFixesAndDiagnostics[0].diagnostic.start === codeFixesAndDiagnostics[j].diagnostic.start) {
+          j++;
+          count++;
         }
+        codeFixesAndDiagnostics.splice(0, count);
       }
     }
   }
-  return true;
+  // TODOFIX - Implement and test this
+  else if (choice === Choices.ACCEPTALL) {
+
+  }
+  else {
+    for (let i = 0; i < codeFixesAndDiagnostics.length; i++) {
+      let count = 1;
+      if (codeFixesAndDiagnostics[i + 1] && codeFixesAndDiagnostics[i].diagnostic.code === codeFixesAndDiagnostics[i + 1].diagnostic.code && codeFixesAndDiagnostics[i].diagnostic.length === codeFixesAndDiagnostics[i + 1].diagnostic.length && codeFixesAndDiagnostics[i].diagnostic.start === codeFixesAndDiagnostics[i + 1].diagnostic.start) {
+        let j = i;
+        while (codeFixesAndDiagnostics[j + 1] && codeFixesAndDiagnostics[j].diagnostic.code === codeFixesAndDiagnostics[j + 1].diagnostic.code && codeFixesAndDiagnostics[j].diagnostic.length === codeFixesAndDiagnostics[j + 1].diagnostic.length && codeFixesAndDiagnostics[j].diagnostic.start === codeFixesAndDiagnostics[j + 1].diagnostic.start) {
+          j++;
+          count++;
+        }
+        codeFixesAndDiagnostics.splice(i + 1, count - 1);
+      }
+    }
+  }
+  return codeFixesAndDiagnostics;
+}
+
+// Removes duplicate code fixes
+function removeDuplicatedFixes(codeFixesAndDiagnostics: FixAndDiagnostic[]): FixAndDiagnostic[] {
+  for (let i = 0; i < codeFixesAndDiagnostics.length; i++) {
+    for (let j = i + 1; j < codeFixesAndDiagnostics.length; j++) {
+      if (i !== j && isEqual(codeFixesAndDiagnostics[i].fix, codeFixesAndDiagnostics[j].fix) && codeFixesAndDiagnostics[i].diagnostic.messageText === codeFixesAndDiagnostics[j].diagnostic.messageText) {
+        codeFixesAndDiagnostics.splice(j, 1);
+      }
+    }
+  }
+  return codeFixesAndDiagnostics;
+}
+
+function getSecondDiagnostic(project: Project, fileName: string, currentCodeFix: CodeFixAction, currentTextChanges: readonly TextChange[]): ChangeDiagnostic {
+  let secondDiagnostic: ChangeDiagnostic = {};
+  let secondFileContents = undefined;
+  let secondFileCurrentLineMap = undefined;
+  const newSourceFile = project.program.getSourceFile(fileName);
+  const secondSourceFile = cloneDeep(newSourceFile)
+  if (secondSourceFile) {
+    secondDiagnostic.file = secondSourceFile;
+    secondDiagnostic.start = currentCodeFix.changes[0].textChanges[0].span.start;
+    secondDiagnostic.length = currentCodeFix.changes[0].textChanges[0].newText.length;
+  }
+  secondFileContents = secondSourceFile ? secondSourceFile.text : undefined;
+  secondFileCurrentLineMap = secondSourceFile ? (secondSourceFile as any).lineMap : undefined;
+  (secondSourceFile as any).lineMap = undefined;
+  if (secondFileContents) {
+    const newFileContents = applyChangestoFile(secondFileContents, currentTextChanges, true);
+    if (secondDiagnostic.file) secondDiagnostic.file.text = newFileContents;
+  }
+  return secondDiagnostic;
+}
+
+//There are more than one quick fix for the same diagnostic
+//If the --showMultiple flag is being used then ask the user which fix to apply, otherwise apply the first fix given for the diagnostic every time
+function isAdditionalFixForSameDiagnostic(codeFixesAndDiagnostics: FixAndDiagnostic[], first: number): boolean {
+  if (codeFixesAndDiagnostics[first + 1]) {
+    const firstDiagnostic = codeFixesAndDiagnostics[first].diagnostic;
+    const secondDiagnostic = codeFixesAndDiagnostics[first + 1].diagnostic;
+    return firstDiagnostic.code === secondDiagnostic.code && firstDiagnostic.length === secondDiagnostic.length && firstDiagnostic.start === secondDiagnostic.start;
+  }
+  return false;
+}
+
+//There is more than one fix being applied on the same line (eg. infer parameter types from usage)
+//If there is more than one fix being applied on the same line we should display them to the user at the same time
+function isAdditionalFixInTheSameLine(codeFixesAndDiagnostics: FixAndDiagnostic[], first: number): boolean {
+  if (codeFixesAndDiagnostics[first + 1]) {
+    const firstDiagnosticAndFix = codeFixesAndDiagnostics[first];
+    const secondDiagnosticAndFix = codeFixesAndDiagnostics[first + 1];
+    return firstDiagnosticAndFix.diagnostic.messageText !== secondDiagnosticAndFix.diagnostic.messageText
+      && firstDiagnosticAndFix.diagnostic.code === secondDiagnosticAndFix.diagnostic.code
+      && firstDiagnosticAndFix.fix.changes[0].fileName === secondDiagnosticAndFix.fix.changes[0].fileName
+      && firstDiagnosticAndFix.fix.changes[0].textChanges.length === secondDiagnosticAndFix.fix.changes[0].textChanges.length
+      && isEqual(firstDiagnosticAndFix.fix.changes[0].textChanges, secondDiagnosticAndFix.fix.changes[0].textChanges);
+  }
+  return false;
+}
+
+function isFixAppliedToTheSameSpan(codeFixesAndDiagnostics: FixAndDiagnostic[], first: number) {
+  if (codeFixesAndDiagnostics[first + 1]) {
+    const firstDiagnosticAndFix = codeFixesAndDiagnostics[first];
+    const secondDiagnosticAndFix = codeFixesAndDiagnostics[first + 1];
+    return firstDiagnosticAndFix.diagnostic.code === secondDiagnosticAndFix.diagnostic.code &&
+      firstDiagnosticAndFix.fix.changes[0].fileName === secondDiagnosticAndFix.fix.changes[0].fileName
+      && firstDiagnosticAndFix.fix.changes[0].textChanges[0].newText !== secondDiagnosticAndFix.fix.changes[0].textChanges[0].newText
+      && firstDiagnosticAndFix.fix.changes[0].textChanges[0].span.start === secondDiagnosticAndFix.fix.changes[0].textChanges[0].span.start
+      && firstDiagnosticAndFix.fix.changes[0].textChanges[0].span.length === secondDiagnosticAndFix.fix.changes[0].textChanges[0].span.length;
+  }
+  return false;
+}
+
+async function displayDiagnostic(project: Project, host: Host, opt: Options, codeFixesAndDiagnostics: FixAndDiagnostic[], codefixes: CodeFixAction[]): Promise<[FixAndDiagnostic[], CodeFixAction[]]> {
+  let currentUpdatedCodeFixes: CodeFixAction[] = [];
+  let updatedFixesAndDiagnostics: FixAndDiagnostic[] = [];
+  const currentCodeFix: CodeFixAction = codeFixesAndDiagnostics[0].fix;
+  const currentDiagnostic = codeFixesAndDiagnostics[0].diagnostic;
+  let diagnosticsInTheSameLine: Diagnostic[] = [];
+  let count = 1;
+
+  if (isAdditionalFixForSameDiagnostic(codeFixesAndDiagnostics, 0)) {
+    let j = 0;
+    while (isAdditionalFixForSameDiagnostic(codeFixesAndDiagnostics, j)) {
+      j++;
+      count++;
+    }
+  }
+
+  if (isAdditionalFixInTheSameLine(codeFixesAndDiagnostics, 0)) {
+    let j = 0;
+    diagnosticsInTheSameLine.push(codeFixesAndDiagnostics[j].diagnostic);
+    while (isAdditionalFixInTheSameLine(codeFixesAndDiagnostics, j)) {
+      j++;
+      count++;
+      diagnosticsInTheSameLine.push(codeFixesAndDiagnostics[j].diagnostic);
+    }
+  }
+
+  //TODOFIX - Implement this for when both fixes are applied to the same span but the fixes aren't equal
+  if (isFixAppliedToTheSameSpan(codeFixesAndDiagnostics, 0)) {
+    console.log("Fix is applied to the same span");
+  }
+
+  if (codeFixesAndDiagnostics[0].fix.changes.length > 1) {
+    //Haven't seen a case where this is true yet
+    host.log("The fix.changes array contains more than one element");
+  }
+  else {
+    let sourceFile = currentDiagnostic.file?.fileName ? project.program.getSourceFile(currentDiagnostic.file?.fileName) : undefined;
+    let currentTextChanges: readonly TextChange[] = currentCodeFix.changes[0].textChanges;
+    const changesFileName = currentCodeFix.changes[0].fileName;
+    let changesOnDifferentLocation = false;
+    if (sourceFile !== undefined) {
+      let secondDiagnostic: ChangeDiagnostic = {}; // Needed when changes are made on a different file or in the same file but a different location
+      const originalContents = sourceFile.text;
+      const currentLineMap = (sourceFile as any).lineMap;
+
+      // Changes are made on a different file
+      if (currentDiagnostic.file?.fileName !== changesFileName) {
+        changesOnDifferentLocation = true;
+        secondDiagnostic = getSecondDiagnostic(project, changesFileName, currentCodeFix, currentTextChanges);
+      }
+      else {
+        let matchesDiagnosticStartAndLength = false;
+        if (currentTextChanges.length === 1) {
+          matchesDiagnosticStartAndLength = currentDiagnostic.start && currentDiagnostic.length ? currentTextChanges[0].span.start === currentDiagnostic.start + currentDiagnostic.length || currentTextChanges[0].span.start === currentDiagnostic.start : false;
+        }
+        // If there are more than one fix
+        if (currentTextChanges.length > 1) {
+          //First check if there's a text change with the start that matches the diagnostic start + length
+          //Second check if there's a text change that matches the start but not start + length
+          matchesDiagnosticStartAndLength = currentTextChanges.find((textChange) => {
+            return (currentDiagnostic.start && currentDiagnostic.length && textChange.span.start === currentDiagnostic.start + currentDiagnostic.length);
+          }) ? true : currentTextChanges.find((textChange) => {
+            return (currentDiagnostic.start && currentDiagnostic.length && textChange.span.start === currentDiagnostic.start);
+          }) ? true : false;
+        }
+
+        // Changes are made in the same file but on a different location
+        if (!matchesDiagnosticStartAndLength) {
+          changesOnDifferentLocation = true;
+          secondDiagnostic = getSecondDiagnostic(project, changesFileName, currentCodeFix, currentTextChanges);
+        }
+      }
+
+      // Changes are made in the same file in the same location where the diagnostic is
+      if (!changesOnDifferentLocation) {
+        (sourceFile as any).lineMap = undefined;
+        const newFileContents = applyChangestoFile(originalContents, currentTextChanges, true);
+        if (currentDiagnostic.file) currentDiagnostic.file.text = newFileContents;
+      }
+
+      diagnosticsInTheSameLine.length ? host.log(formatDiagnosticsWithColorAndContextTsFix(diagnosticsInTheSameLine, host)) : host.log(formatDiagnosticsWithColorAndContext([currentDiagnostic], host));
+
+      // Display fix on different location
+      if (changesOnDifferentLocation && secondDiagnostic) {
+        host.log(`Please review the fix below for the diagnostic above`);
+        host.log(formatFixOnADifferentLocation([secondDiagnostic], host));
+      }
+
+      //Get user's choice and updated fixes and diagnostics
+      const showMultiple = opt.showMultiple && count > 1 && !diagnosticsInTheSameLine.length;
+      [updatedFixesAndDiagnostics, currentUpdatedCodeFixes] = await getUpdatedCodeFixesAndDiagnostics(codeFixesAndDiagnostics, codefixes, count, showMultiple); //TODOFIX - I believe that if I have diagnosticsInTheSameLine as an argument, I can eliminate duplicates in codefixes
+
+      //Reset text and lineMap to their original contents
+      if (currentDiagnostic.file) currentDiagnostic.file.text = originalContents;
+      (sourceFile as any).lineMap = currentLineMap;
+
+    }
+  }
+  return [updatedFixesAndDiagnostics, currentUpdatedCodeFixes];
+}
+
+async function getFileFixes(project: Project, host: Host, opt: Options, codeFixesAndDiagnostics: FixAndDiagnostic[]): Promise<CodeFixAction[]> {
+  let codefixes: CodeFixAction[] = [];
+  let updatedFixesAndDiagnostics: FixAndDiagnostic[] = [];
+  let currentUpdatedCodeFixes: CodeFixAction[] = [];
+
+  for (let i = 0; i < codeFixesAndDiagnostics.length; i++) {
+    [updatedFixesAndDiagnostics, currentUpdatedCodeFixes] = await displayDiagnostic(project, host, opt, codeFixesAndDiagnostics, codefixes);
+    codeFixesAndDiagnostics = updatedFixesAndDiagnostics;
+    codefixes = currentUpdatedCodeFixes;
+    i = -1;
+  }
+  return codefixes;
 }
 
 async function getChangedFiles(project: Project, textChanges: Map<string, TextChange[]>): Promise<{ changedFiles: ReadonlyMap<string, ChangedFile>; excessChanges: ReadonlyMap<string, readonly TextChange[]>; }> {
@@ -511,7 +859,7 @@ async function getChangedFiles(project: Project, textChanges: Map<string, TextCh
 
 function applyCodefixesInFile(originalContents: string, textChanges: TextChange[]): [TextChange[], string] {
   // sort textchanges by start
-  const sortedFixList = sortChangesByStart(textChanges);
+  const sortedFixList = sortChangesByStart(textChanges); //Adds duplicates
 
   // take some sort of issue (or none) with overlapping textchanges
   const [filteredFixList, notAppliedFixes] = filterOverlappingFixes(sortedFixList);
@@ -551,53 +899,88 @@ export function filterOverlappingFixes(sortedFixList: TextChange[]): [TextChange
 }
 
 enum Choices {
-  accept = "Accept",
-  reject = "Reject"
+  ACCEPT = 'Accept',
+  ACCEPTALL = 'Accept all quick fixes for this diagnostic code in this pass',
+  BACK = 'Go back',
+  SKIPALL = 'Skip this diagnostic code this pass',
+  SKIP = 'Skip',
+  SHOWMULTIPLE = 'Show more quick fixes for this diagnostic'
 }
 
-async function getInputFromUser(codefix: string): Promise<string> {
+async function getInputFromUser(codefix: CodeFixAction, showMultiple?: boolean): Promise<string> {
   const choice = await inquirer
     .prompt([
       {
         name: "choice",
         type: "list",
-        message: `Would you like to apply the ${codefix} fix?`,
-        choices: [Choices.accept, Choices.reject]
+        message: `Would you like to apply the ${codefix.fixName} fix with description "${codefix.description}"?`,
+        choices: showMultiple ? [Choices.ACCEPT, Choices.ACCEPTALL, Choices.SKIPALL, Choices.SKIP, Choices.SHOWMULTIPLE] : [Choices.ACCEPT, Choices.ACCEPTALL, Choices.SKIPALL, Choices.SKIP]
       },
     ]);
   return choice.choice;
 };
 
 
-function applyChangestoFile(originalContents: string, fixList: readonly TextChange[]): string {
+function applyChangestoFile(originalContents: string, fixList: readonly TextChange[], isGetFileFixes?: boolean): string {
   // maybe we want to have this and subsequent functions to return a diagnostic
   // function expects fixList to be already sorted and filtered
-  const newFileContents = doTextChanges(originalContents, fixList);
+  const newFileContents = doTextChanges(originalContents, fixList, isGetFileFixes);
   return newFileContents;
 }
 
-export function doTextChanges(fileText: string, textChanges: readonly TextChange[]): string {
+export function doTextChanges(fileText: string, textChanges: readonly TextChange[], isGetFileFixes?: boolean): string {
   // does js/ts do references? Or is it always a copy when you pass into a function
   // iterate through codefixes from back
   for (let i = textChanges.length - 1; i >= 0; i--) {
     // apply each codefix
-    fileText = doTextChangeOnString(fileText, textChanges[i]);
+    fileText = doTextChangeOnString(fileText, textChanges[i], isGetFileFixes);
   }
   return fileText;
 }
 
-export function doTextChangeOnString(currentFileText: string, change: TextChange): string {
+export function doTextChangeOnString(currentFileText: string, change: TextChange, isGetFileFixes?: boolean): string {
   const prefix = currentFileText.substring(0, change.span.start);
-  const middle = `\x1b[32m${change.newText}\x1b[0m`;
+  let middle = "";
+  // if (isGetFileFixes) middle = `\x1b[32m${change.newText}\x1b[0m`;
+  if (isGetFileFixes) middle = compareContentsAndLog(currentFileText.substring(change.span.start, change.span.start + change.span.length), change.newText);
+  else middle = change.newText;
   // const middle = change.newText;
   const suffix = currentFileText.substring(change.span.start + change.span.length);
   return prefix + middle + suffix;
 }
 
+function compareContentsAndLog(str1: string, str2: string): string {
+  let diff = diffChars(str1, str2);
+  let middleString = "";
+  let newLine = "\r\n";
+  diff.forEach((part) => {
+    // green for additions, red for deletions
+    // unset for common parts
+    let color;
+    if (part.added) color = 32;
+    if (part.removed) color = 31;
+    if (part.added || part.removed) {
+      //Purely aesthetics
+      if (part.value.startsWith(newLine)) {
+        middleString += newLine;
+        middleString += `\x1b[${color}m${part.value.substring(2)}\x1b[0m`;
+      }
+      else {
+        middleString += `\x1b[${color}m${part.value}\x1b[0m`;
+      }
+
+    }
+    else {
+      middleString += `${part.value}`;
+    }
+  });
+  return middleString;
+}
+
 function hasOnlyEmptyLists(m: ReadonlyMap<any, readonly any[]>): boolean {
   let arrayLength = 0;
   for (const [_, entries] of m.entries()) {
-    if (entries.length > 0) {
+    if (entries.length) {
       arrayLength++;
     }
   }
@@ -620,24 +1003,8 @@ export function getRelativePath(filePath: string, opt: Options): string {
 
 export function getOutputFilePath(filePath: string, opt: Options): string {
   // this function uses absolute paths
-
   const fileName = getRelativePath(filePath, opt);
   return path.resolve(opt.outputFolder, fileName);
-}
-
-function compareContentsAndLog(host: Host, str1: string, str2: string): void {//TODOFIX might not need anymore once I fix the other function
-  let diff = diffChars(str1, str2);
-  let stringDiff = "";
-  diff.forEach((part) => {
-    // green for additions, red for deletions
-    // unset for common parts
-    let color;
-    if (part.added) color = 32;
-    if (part.removed) color = 31;
-    (part.added || part.removed) ? host.write(`\x1b[${color}m${part.value}\x1b[0m`) : host.write(`${part.value}`);
-  });
-  host.write(`\n`);
-  host.write(stringDiff)
 }
 
 function writeToFile(fileName: string, fileContents: string, opt: Options, host: Host): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,6 @@ export interface Options {
   file: string[];
   fixName: string[];
   write: boolean,
-  fix: boolean,
   showMultiple: boolean,
   interactiveMode: boolean,
   ignoreGitStatus: boolean
@@ -309,7 +308,7 @@ export async function getCodeFixesFromProject(project: Project, opt: Options, ho
   }
   fixesAndDiagnostics = removeDuplicatedFixes(fixesAndDiagnostics);
 
-  host.log(`${fixesAndDiagnostics.length} will be applied. There are ${noAppliedFixes.length} no applied fixes`);
+  host.log(`Fixes to be applied: ${fixesAndDiagnostics.length}\nNo applied fixes: ${noAppliedFixes.length}`);
 
   if (opt.interactiveMode) {
     codefixes = await getFileFixes(project, host, fixesAndDiagnostics, opt.showMultiple);

--- a/src/ts.ts
+++ b/src/ts.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import path from "path";
 import importCwd from "import-cwd";
 import type { LanguageService, LanguageServiceHost, ParseConfigFileHost, Program } from "typescript";

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,680 @@
+import { Diagnostic, getLineAndCharacterOfPosition, getPositionOfLineAndCharacter, SourceFile } from "typescript";
+import { ChangeDiagnostic, Host } from ".";
+
+const resetEscapeSequence = "\u001b[0m";
+const urlSchemeSeparator = "://";
+const altDirectorySeparator = "\\";
+const directorySeparator = "/";
+const backslashRegExp = /\\/g;
+const relativePathSegmentRegExp = /(?:\/\/)|(?:^|\/)\.\.?(?:$|\/)/;
+const ellipsis = "...";
+const halfIndent = "  ";
+const indent = "    ";
+const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
+const gutterStyleSequence = "\u001b[7m";
+const gutterSeparator = " ";
+
+enum ForegroundColorEscapeSequences {
+    Grey = "\u001b[90m",
+    Red = "\u001b[91m",
+    Yellow = "\u001b[93m",
+    Blue = "\u001b[94m",
+    Cyan = "\u001b[96m"
+}
+
+const enum CharacterCodes {
+    nullCharacter = 0,
+    maxAsciiCharacter = 0x7F,
+
+    lineFeed = 0x0A,              // \n
+    carriageReturn = 0x0D,        // \r
+    lineSeparator = 0x2028,
+    paragraphSeparator = 0x2029,
+    nextLine = 0x0085,
+
+    // Unicode 3.0 space characters
+    space = 0x0020,   // " "
+    nonBreakingSpace = 0x00A0,   //
+    enQuad = 0x2000,
+    emQuad = 0x2001,
+    enSpace = 0x2002,
+    emSpace = 0x2003,
+    threePerEmSpace = 0x2004,
+    fourPerEmSpace = 0x2005,
+    sixPerEmSpace = 0x2006,
+    figureSpace = 0x2007,
+    punctuationSpace = 0x2008,
+    thinSpace = 0x2009,
+    hairSpace = 0x200A,
+    zeroWidthSpace = 0x200B,
+    narrowNoBreakSpace = 0x202F,
+    ideographicSpace = 0x3000,
+    mathematicalSpace = 0x205F,
+    ogham = 0x1680,
+
+    _ = 0x5F,
+    $ = 0x24,
+
+    _0 = 0x30,
+    _1 = 0x31,
+    _2 = 0x32,
+    _3 = 0x33,
+    _4 = 0x34,
+    _5 = 0x35,
+    _6 = 0x36,
+    _7 = 0x37,
+    _8 = 0x38,
+    _9 = 0x39,
+
+    a = 0x61,
+    b = 0x62,
+    c = 0x63,
+    d = 0x64,
+    e = 0x65,
+    f = 0x66,
+    g = 0x67,
+    h = 0x68,
+    i = 0x69,
+    j = 0x6A,
+    k = 0x6B,
+    l = 0x6C,
+    m = 0x6D,
+    n = 0x6E,
+    o = 0x6F,
+    p = 0x70,
+    q = 0x71,
+    r = 0x72,
+    s = 0x73,
+    t = 0x74,
+    u = 0x75,
+    v = 0x76,
+    w = 0x77,
+    x = 0x78,
+    y = 0x79,
+    z = 0x7A,
+
+    A = 0x41,
+    B = 0x42,
+    C = 0x43,
+    D = 0x44,
+    E = 0x45,
+    F = 0x46,
+    G = 0x47,
+    H = 0x48,
+    I = 0x49,
+    J = 0x4A,
+    K = 0x4B,
+    L = 0x4C,
+    M = 0x4D,
+    N = 0x4E,
+    O = 0x4F,
+    P = 0x50,
+    Q = 0x51,
+    R = 0x52,
+    S = 0x53,
+    T = 0x54,
+    U = 0x55,
+    V = 0x56,
+    W = 0x57,
+    X = 0x58,
+    Y = 0x59,
+    Z = 0x5a,
+
+    ampersand = 0x26,             // &
+    asterisk = 0x2A,              // *
+    at = 0x40,                    // @
+    backslash = 0x5C,             // \
+    backtick = 0x60,              // `
+    bar = 0x7C,                   // |
+    caret = 0x5E,                 // ^
+    closeBrace = 0x7D,            // }
+    closeBracket = 0x5D,          // ]
+    closeParen = 0x29,            // )
+    colon = 0x3A,                 // :
+    comma = 0x2C,                 // ,
+    dot = 0x2E,                   // .
+    doubleQuote = 0x22,           // "
+    equals = 0x3D,                // =
+    exclamation = 0x21,           // !
+    greaterThan = 0x3E,           // >
+    hash = 0x23,                  // #
+    lessThan = 0x3C,              // <
+    minus = 0x2D,                 // -
+    openBrace = 0x7B,             // {
+    openBracket = 0x5B,           // [
+    openParen = 0x28,             // (
+    percent = 0x25,               // %
+    plus = 0x2B,                  // +
+    question = 0x3F,              // ?
+    semicolon = 0x3B,             // ;
+    singleQuote = 0x27,           // '
+    slash = 0x2F,                 // /
+    tilde = 0x7E,                 // ~
+
+    backspace = 0x08,             // \b
+    formFeed = 0x0C,              // \f
+    byteOrderMark = 0xFEFF,
+    tab = 0x09,                   // \t
+    verticalTab = 0x0B,           // \v
+}
+
+function formatColorAndReset(text: string, formatStyle: string) {
+    return formatStyle + text + resetEscapeSequence;
+}
+
+function isVolumeCharacter(charCode: number) {
+    return (charCode >= CharacterCodes.a && charCode <= CharacterCodes.z) ||
+        (charCode >= CharacterCodes.A && charCode <= CharacterCodes.Z);
+}
+
+function getFileUrlVolumeSeparatorEnd(url: string, start: number) {
+    const ch0 = url.charCodeAt(start);
+    if (ch0 === CharacterCodes.colon) return start + 1;
+    if (ch0 === CharacterCodes.percent && url.charCodeAt(start + 1) === CharacterCodes._3) {
+        const ch2 = url.charCodeAt(start + 2);
+        if (ch2 === CharacterCodes.a || ch2 === CharacterCodes.A) return start + 3;
+    }
+    return -1;
+}
+
+function getEncodedRootLength(path: string): number {
+    if (!path) return 0;
+    const ch0 = path.charCodeAt(0);
+
+    // POSIX or UNC
+    if (ch0 === CharacterCodes.slash || ch0 === CharacterCodes.backslash) {
+        if (path.charCodeAt(1) !== ch0) return 1; // POSIX: "/" (or non-normalized "\")
+
+        const p1 = path.indexOf(ch0 === CharacterCodes.slash ? directorySeparator : altDirectorySeparator, 2);
+        if (p1 < 0) return path.length; // UNC: "//server" or "\\server"
+
+        return p1 + 1; // UNC: "//server/" or "\\server\"
+    }
+
+    // DOS
+    if (isVolumeCharacter(ch0) && path.charCodeAt(1) === CharacterCodes.colon) {
+        const ch2 = path.charCodeAt(2);
+        if (ch2 === CharacterCodes.slash || ch2 === CharacterCodes.backslash) return 3; // DOS: "c:/" or "c:\"
+        if (path.length === 2) return 2; // DOS: "c:" (but not "c:d")
+    }
+
+    // URL
+    const schemeEnd = path.indexOf(urlSchemeSeparator);
+    if (schemeEnd !== -1) {
+        const authorityStart = schemeEnd + urlSchemeSeparator.length;
+        const authorityEnd = path.indexOf(directorySeparator, authorityStart);
+        if (authorityEnd !== -1) { // URL: "file:///", "file://server/", "file://server/path"
+            // For local "file" URLs, include the leading DOS volume (if present).
+            // Per https://www.ietf.org/rfc/rfc1738.txt, a host of "" or "localhost" is a
+            // special case interpreted as "the machine from which the URL is being interpreted".
+            const scheme = path.slice(0, schemeEnd);
+            const authority = path.slice(authorityStart, authorityEnd);
+            if (scheme === "file" && (authority === "" || authority === "localhost") &&
+                isVolumeCharacter(path.charCodeAt(authorityEnd + 1))) {
+                const volumeSeparatorEnd = getFileUrlVolumeSeparatorEnd(path, authorityEnd + 2);
+                if (volumeSeparatorEnd !== -1) {
+                    if (path.charCodeAt(volumeSeparatorEnd) === CharacterCodes.slash) {
+                        // URL: "file:///c:/", "file://localhost/c:/", "file:///c%3a/", "file://localhost/c%3a/"
+                        return ~(volumeSeparatorEnd + 1);
+                    }
+                    if (volumeSeparatorEnd === path.length) {
+                        // URL: "file:///c:", "file://localhost/c:", "file:///c$3a", "file://localhost/c%3a"
+                        // but not "file:///c:d" or "file:///c%3ad"
+                        return ~volumeSeparatorEnd;
+                    }
+                }
+            }
+            return ~(authorityEnd + 1); // URL: "file://server/", "http://server/"
+        }
+        return ~path.length; // URL: "file://server", "http://server"
+    }
+
+    // relative
+    return 0;
+}
+
+function isRootedDiskPath(path: string) {
+    return getEncodedRootLength(path) > 0;
+}
+
+function isAnyDirectorySeparator(charCode: number): boolean {
+    return charCode === CharacterCodes.slash || charCode === CharacterCodes.backslash;
+}
+
+function hasTrailingDirectorySeparator(path: string) {
+    return path.length > 0 && isAnyDirectorySeparator(path.charCodeAt(path.length - 1));
+}
+
+function ensureTrailingDirectorySeparator(path: string) {
+    if (!hasTrailingDirectorySeparator(path)) {
+        return path + directorySeparator;
+    }
+
+    return path;
+}
+
+function getPathFromPathComponents(pathComponents: readonly string[]) {
+    if (pathComponents.length === 0) return "";
+
+    const root = pathComponents[0] && ensureTrailingDirectorySeparator(pathComponents[0]);
+    return root + pathComponents.slice(1).join(directorySeparator);
+}
+
+function some<T>(array: readonly T[] | undefined, predicate?: (value: T) => boolean): boolean {
+    if (array) {
+        if (predicate) {
+            for (const v of array) {
+                if (predicate(v)) {
+                    return true;
+                }
+            }
+        }
+        else {
+            return array.length > 0;
+        }
+    }
+    return false;
+}
+
+function reducePathComponents(components: readonly string[]) {
+    if (!some(components)) return [];
+    const reduced = [components[0]];
+    for (let i = 1; i < components.length; i++) {
+        const component = components[i];
+        if (!component) continue;
+        if (component === ".") continue;
+        if (component === "..") {
+            if (reduced.length > 1) {
+                if (reduced[reduced.length - 1] !== "..") {
+                    reduced.pop();
+                    continue;
+                }
+            }
+            else if (reduced[0]) continue;
+        }
+        reduced.push(component);
+    }
+    return reduced;
+}
+
+function normalizeSlashes(path: string): string {
+    const index = path.indexOf("\\");
+    if (index === -1) {
+        return path;
+    }
+    backslashRegExp.lastIndex = index; // prime regex with known position
+    return path.replace(backslashRegExp, directorySeparator);
+}
+
+function combinePaths(path: string, ...paths: (string | undefined)[]): string {
+    if (path) path = normalizeSlashes(path);
+    for (let relativePath of paths) {
+        if (!relativePath) continue;
+        relativePath = normalizeSlashes(relativePath);
+        if (!path || getRootLength(relativePath) !== 0) {
+            path = relativePath;
+        }
+        else {
+            path = ensureTrailingDirectorySeparator(path) + relativePath;
+        }
+    }
+    return path;
+}
+
+function getRootLength(path: string) {
+    const rootLength = getEncodedRootLength(path);
+    return rootLength < 0 ? ~rootLength : rootLength;
+}
+
+function lastOrUndefined<T>(array: readonly T[] | undefined): T | undefined {
+    return array === undefined || array.length === 0 ? undefined : array[array.length - 1];
+}
+
+function pathComponents(path: string, rootLength: number) {
+    const root = path.substring(0, rootLength);
+    const rest = path.substring(rootLength).split(directorySeparator);
+    if (rest.length && !lastOrUndefined(rest)) rest.pop();
+    return [root, ...rest];
+}
+
+function getPathComponents(path: string, currentDirectory = "") {
+    path = combinePaths(currentDirectory, path);
+    return pathComponents(path, getRootLength(path));
+}
+
+function equateStringsCaseInsensitive(a: string, b: string) {
+    return a === b
+        || a !== undefined
+        && b !== undefined
+        && a.toUpperCase() === b.toUpperCase();
+}
+
+function identity<T>(x: T) {
+    return x;
+}
+
+function toLowerCase(x: string) {
+    return x.toLowerCase();
+}
+
+function toFileNameLowerCase(x: string) {
+    return fileNameLowerCaseRegExp.test(x) ?
+        x.replace(fileNameLowerCaseRegExp, toLowerCase) :
+        x;
+}
+
+export type GetCanonicalFileName = (fileName: string) => string;
+export function createGetCanonicalFileName(useCaseSensitiveFileNames: boolean): GetCanonicalFileName {
+    return useCaseSensitiveFileNames ? identity : toFileNameLowerCase;
+}
+
+function getPathComponentsRelativeTo(from: string, to: string, stringEqualityComparer: (a: string, b: string) => boolean, getCanonicalFileName: GetCanonicalFileName) {
+    const fromComponents = reducePathComponents(getPathComponents(from));
+    const toComponents = reducePathComponents(getPathComponents(to));
+
+    let start: number;
+    for (start = 0; start < fromComponents.length && start < toComponents.length; start++) {
+        const fromComponent = getCanonicalFileName(fromComponents[start]);
+        const toComponent = getCanonicalFileName(toComponents[start]);
+        const comparer = start === 0 ? equateStringsCaseInsensitive : stringEqualityComparer;
+        if (!comparer(fromComponent, toComponent)) break;
+    }
+
+    if (start === 0) {
+        return toComponents;
+    }
+
+    const components = toComponents.slice(start);
+    const relative: string[] = [];
+    for (; start < fromComponents.length; start++) {
+        relative.push("..");
+    }
+    return ["", ...relative, ...components];
+}
+
+function normalizePath(path: string): string {
+    path = normalizeSlashes(path);
+    // Most paths don't require normalization
+    if (!relativePathSegmentRegExp.test(path)) {
+        return path;
+    }
+    // Some paths only require cleanup of `/./` or leading `./`
+    const simplified = path.replace(/\/\.\//g, "/").replace(/^\.\//, "");
+    if (simplified !== path) {
+        path = simplified;
+        if (!relativePathSegmentRegExp.test(path)) {
+            return path;
+        }
+    }
+    // Other paths require full normalization
+    const normalized = getPathFromPathComponents(reducePathComponents(getPathComponents(path)));
+    return normalized && hasTrailingDirectorySeparator(path) ? ensureTrailingDirectorySeparator(normalized) : normalized;
+}
+
+function resolvePath(path: string, ...paths: (string | undefined)[]): string {
+    return normalizePath(some(paths) ? combinePaths(path, ...paths) : normalizeSlashes(path));
+}
+
+function equateValues<T>(a: T, b: T) {
+    return a === b;
+}
+
+function equateStringsCaseSensitive(a: string, b: string) {
+    return equateValues(a, b);
+}
+
+function getRelativePathToDirectoryOrUrl(directoryPathOrUrl: string, relativeOrAbsolutePath: string, currentDirectory: string, getCanonicalFileName: GetCanonicalFileName, isAbsolutePathAnUrl: boolean) {
+    const pathComponents = getPathComponentsRelativeTo(
+        resolvePath(currentDirectory, directoryPathOrUrl),
+        resolvePath(currentDirectory, relativeOrAbsolutePath),
+        equateStringsCaseSensitive,
+        getCanonicalFileName
+    );
+
+    const firstComponent = pathComponents[0];
+    if (isAbsolutePathAnUrl && isRootedDiskPath(firstComponent)) {
+        const prefix = firstComponent.charAt(0) === directorySeparator ? "file://" : "file:///";
+        pathComponents[0] = prefix + firstComponent;
+    }
+
+    return getPathFromPathComponents(pathComponents);
+}
+
+function convertToRelativePath(absoluteOrRelativePath: string, basePath: string, getCanonicalFileName: (path: string) => string): string {
+    return !isRootedDiskPath(absoluteOrRelativePath)
+        ? absoluteOrRelativePath
+        : getRelativePathToDirectoryOrUrl(basePath, absoluteOrRelativePath, basePath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
+}
+
+function formatLocation(file: SourceFile, start: number, host: Host, color = formatColorAndReset) {
+    const { line: firstLine, character: firstLineChar } = getLineAndCharacterOfPosition(file, start); // TODO: GH#18217
+    const relativeFileName = host ? convertToRelativePath(file.fileName, host.getCurrentDirectory(), (fileName: string) => host.getCanonicalFileName(fileName)) : file.fileName;
+
+    let output = "";
+    output += color(relativeFileName, ForegroundColorEscapeSequences.Cyan);
+    output += ":";
+    output += color(`${firstLine + 1}`, ForegroundColorEscapeSequences.Yellow);
+    output += ":";
+    output += color(`${firstLineChar + 1}`, ForegroundColorEscapeSequences.Yellow);
+    return output;
+}
+
+enum DiagnosticCategory {
+    Warning,
+    Error,
+    Suggestion,
+    Message
+}
+
+function diagnosticCategoryName(d: { category: DiagnosticCategory }, lowerCase = true): string {
+    const name = DiagnosticCategory[d.category];
+    return lowerCase ? name.toLowerCase() : name;
+}
+
+interface DiagnosticMessageChain {
+    messageText: string;
+    category: DiagnosticCategory;
+    code: number;
+    next?: DiagnosticMessageChain[];
+}
+
+function isString(text: unknown): text is string {
+    return typeof text === "string";
+}
+
+function flattenDiagnosticMessageText(diag: string | DiagnosticMessageChain | undefined, newLine: string, indent = 0): string {
+    if (isString(diag)) {
+        return diag;
+    }
+    else if (diag === undefined) {
+        return "";
+    }
+    let result = "";
+    if (indent) {
+        result += newLine;
+
+        for (let i = 0; i < indent; i++) {
+            result += "  ";
+        }
+    }
+    result += diag.messageText;
+    indent++;
+    if (diag.next) {
+        for (const kid of diag.next) {
+            result += flattenDiagnosticMessageText(kid, newLine, indent);
+        }
+    }
+    return result;
+}
+
+function padLeft(s: string, length: number, padString: " " | "0" = " ") {
+    return length <= s.length ? s : padString.repeat(length - s.length) + s;
+}
+
+function isWhiteSpaceSingleLine(ch: number): boolean {
+    // Note: nextLine is in the Zs space, and should be considered to be a whitespace.
+    // It is explicitly not a line-break as it isn't in the exact set specified by EcmaScript.
+    return ch === CharacterCodes.space ||
+        ch === CharacterCodes.tab ||
+        ch === CharacterCodes.verticalTab ||
+        ch === CharacterCodes.formFeed ||
+        ch === CharacterCodes.nonBreakingSpace ||
+        ch === CharacterCodes.nextLine ||
+        ch === CharacterCodes.ogham ||
+        ch >= CharacterCodes.enQuad && ch <= CharacterCodes.zeroWidthSpace ||
+        ch === CharacterCodes.narrowNoBreakSpace ||
+        ch === CharacterCodes.mathematicalSpace ||
+        ch === CharacterCodes.ideographicSpace ||
+        ch === CharacterCodes.byteOrderMark;
+}
+
+function isLineBreak(ch: number): boolean {
+    // ES5 7.3:
+    // The ECMAScript line terminator characters are listed in Table 3.
+    //     Table 3: Line Terminator Characters
+    //     Code Unit Value     Name                    Formal Name
+    //     \u000A              Line Feed               <LF>
+    //     \u000D              Carriage Return         <CR>
+    //     \u2028              Line separator          <LS>
+    //     \u2029              Paragraph separator     <PS>
+    // Only the characters in Table 3 are treated as line terminators. Other new line or line
+    // breaking characters are treated as white space but not as line terminators.
+
+    return ch === CharacterCodes.lineFeed ||
+        ch === CharacterCodes.carriageReturn ||
+        ch === CharacterCodes.lineSeparator ||
+        ch === CharacterCodes.paragraphSeparator;
+}
+
+function isWhiteSpaceLike(ch: number): boolean {
+    return isWhiteSpaceSingleLine(ch) || isLineBreak(ch);
+}
+
+function trimEndImpl(s: string) {
+    let end = s.length - 1;
+    while (end >= 0) {
+        if (!isWhiteSpaceLike(s.charCodeAt(end))) break;
+        end--;
+    }
+    return s.slice(0, end + 1);
+}
+
+const trimStringEnd = !!String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
+
+function formatCodeSpan(file: SourceFile, start: number, length: number, indent: string, host: Host) {
+    const { line: firstLine, character: firstLineChar } = getLineAndCharacterOfPosition(file, start);
+    const { line: lastLine, character: lastLineChar } = getLineAndCharacterOfPosition(file, start + length);
+    const lastLineInFile = getLineAndCharacterOfPosition(file, file.text.length).line;
+
+    const hasMoreThanFiveLines = (lastLine - firstLine) >= 4;
+    let gutterWidth = (lastLine + 1 + "").length;
+    if (hasMoreThanFiveLines) {
+        gutterWidth = Math.max(ellipsis.length, gutterWidth);
+    }
+
+    let context = "";
+    for (let i = firstLine; i <= lastLine; i++) {
+        context += host.getNewLine();
+        // If the error spans over 5 lines, we'll only show the first 2 and last 2 lines,
+        // so we'll skip ahead to the second-to-last line.
+        if (hasMoreThanFiveLines && firstLine + 1 < i && i < lastLine - 1) {
+            context += indent + formatColorAndReset(padLeft(ellipsis, gutterWidth), gutterStyleSequence) + gutterSeparator + host.getNewLine();
+            i = lastLine - 1;
+        }
+
+        const lineStart = getPositionOfLineAndCharacter(file, i, 0);
+        const lineEnd = i < lastLineInFile ? getPositionOfLineAndCharacter(file, i + 1, 0) : file.text.length;
+        let lineContent = file.text.slice(lineStart, lineEnd);
+        lineContent = trimStringEnd(lineContent);  // trim from end
+        lineContent = lineContent.replace(/\t/g, " ");   // convert tabs to single spaces
+
+        // Output the gutter and the actual contents of the line.
+        context += indent + formatColorAndReset(padLeft(i + 1 + "", gutterWidth), gutterStyleSequence) + gutterSeparator;
+        context += lineContent + host.getNewLine();
+
+        // Output the gutter and the error span for the line using tildes.
+        context += indent + formatColorAndReset(padLeft("", gutterWidth), gutterStyleSequence) + gutterSeparator;
+        // context += squiggleColor;
+        // if (i === firstLine) {
+        //     // If we're on the last line, then limit it to the last character of the last line.
+        //     // Otherwise, we'll just squiggle the rest of the line, giving 'slice' no end position.
+        //     const lastCharForLine = i === lastLine ? lastLineChar : undefined;
+
+        //     context += lineContent.slice(0, firstLineChar).replace(/\S/g, " ");
+        //     context += lineContent.slice(firstLineChar, lastCharForLine).replace(/./g, "~");
+        // }
+        // else if (i === lastLine) {
+        //     context += lineContent.slice(0, lastLineChar).replace(/./g, "~");
+        // }
+        // else {
+        //     // Squiggle the entire line.
+        //     context += lineContent.replace(/./g, "~");
+        // }
+        context += resetEscapeSequence;
+    }
+    return context;
+}
+
+function getCategoryFormat(category: DiagnosticCategory): ForegroundColorEscapeSequences {
+    switch (category) {
+        case DiagnosticCategory.Error: return ForegroundColorEscapeSequences.Red;
+        case DiagnosticCategory.Warning: return ForegroundColorEscapeSequences.Yellow;
+        // case DiagnosticCategory.Suggestion: return Debug.fail("Should never get an Info diagnostic on the command line.");
+        case DiagnosticCategory.Suggestion: return ForegroundColorEscapeSequences.Cyan;
+        case DiagnosticCategory.Message: return ForegroundColorEscapeSequences.Blue;
+    }
+}
+
+//TODOFIX Combine formatFixOnADifferentLocation and formatDiagnosticsWithColorAndContextTsFix into one function
+export function formatFixOnADifferentLocation(diagnostics: readonly ChangeDiagnostic[], host: Host): string {
+    let output = "";
+    for (const diagnostic of diagnostics) {
+        if (diagnostic.file) {
+            const { file, start } = diagnostic;
+            output += formatLocation(file, start!, host);
+        }
+
+        if (diagnostic.file) {
+            output += host.getNewLine();
+            output += formatCodeSpan(diagnostic.file, diagnostic.start!, diagnostic.length!, "", host); // TODO: GH#18217 // TODOFIX change this to show additions and removals
+        }
+
+        output += host.getNewLine();
+    }
+    return output;
+}
+
+export function formatDiagnosticsWithColorAndContextTsFix(diagnostics: readonly Diagnostic[], host: Host): string {
+    let output = "";
+    for (const diagnostic of diagnostics) {
+        if (diagnostic.file) {
+            const { file, start } = diagnostic;
+            output += formatLocation(file, start!, host); // TODO: GH#18217
+            output += " - ";
+        }
+
+        output += formatColorAndReset(diagnosticCategoryName(diagnostic), getCategoryFormat(diagnostic.category));
+        output += formatColorAndReset(` TS${diagnostic.code}: `, ForegroundColorEscapeSequences.Grey);
+        output += flattenDiagnosticMessageText(diagnostic.messageText, host.getNewLine());
+        output += host.getNewLine();
+    }
+    if (diagnostics[0].file) {
+        output += formatCodeSpan(diagnostics[0].file, diagnostics[0].start!, diagnostics[0].length!, "", host); // TODO: GH#18217
+        // output += formatCodeSpan(diagnostics[0].file, diagnostics[0].start!, diagnostics[0].length!, "", getCategoryFormat(diagnostics[0].category), host);
+    }
+    // if (diagnostic.relatedInformation) {
+    //     output += host.getNewLine();
+    //     for (const { file, start, length, messageText } of diagnostic.relatedInformation) {
+    //         if (file) {
+    //             output += host.getNewLine();
+    //             output += halfIndent + formatLocation(file, start!, host); // TODO: GH#18217
+    //             output += formatCodeSpan(file, start!, length!, indent, ForegroundColorEscapeSequences.Cyan, host); // TODO: GH#18217
+    //         }
+    //         output += host.getNewLine();
+    //         output += indent + flattenDiagnosticMessageText(messageText, host.getNewLine());
+    //     }
+    // }
+    output += host.getNewLine();
+
+    return output;
+}

--- a/test/unit/doTextChangeOnString.test.ts
+++ b/test/unit/doTextChangeOnString.test.ts
@@ -1,5 +1,4 @@
 import { doTextChangeOnString } from "../../src/index";
-// import path from "path";
 import { TextChange } from "typescript";
 
 test("textChangeOnString1", () => {

--- a/test/unit/filterDiagnostics.test.ts
+++ b/test/unit/filterDiagnostics.test.ts
@@ -1,4 +1,4 @@
-import { filterDiagnosticsByErrorCode } from "../../src/index";
+import { filterDiagnosticsByFileAndErrorCode } from "../../src/index";
 import { Diagnostic } from "typescript";
 
 const default_codes = [];
@@ -21,12 +21,12 @@ function makeDiagnostic(code:number, fileName?: string):TestDiagnostic {
 
 test("filterDiagnostics_noErrorsInOpt_oneFile", () => {
     const originalDiagnostics = [[makeDiagnostic(111), makeDiagnostic(222), makeDiagnostic(333)]];
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, default_codes);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, default_codes);
     expect(results[0]).toEqual(originalDiagnostics);
     expect(results[1]).toEqual(["Found 3 diagnostics in 1 files"]);
 
     const diagnosticsRepeatedError = [[makeDiagnostic(111), makeDiagnostic(333), makeDiagnostic(111)]];
-    const resultsRepeatedError = filterDiagnosticsByErrorCode(diagnosticsRepeatedError, default_codes);
+    const resultsRepeatedError = filterDiagnosticsByFileAndErrorCode(diagnosticsRepeatedError, default_codes);
     expect(resultsRepeatedError[0]).toEqual(diagnosticsRepeatedError);
     expect(resultsRepeatedError[1]).toEqual(["Found 3 diagnostics in 1 files"]);
 })
@@ -34,14 +34,14 @@ test("filterDiagnostics_noErrorsInOpt_oneFile", () => {
 test("filterDiagnostics_noErrorsInOpt_multiFiles", () => {
     const originalDiagnostics = [[makeDiagnostic(111), makeDiagnostic(222), makeDiagnostic(333)],
         [makeDiagnostic(444), makeDiagnostic(444), makeDiagnostic(111)]];
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, default_codes);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, default_codes);
     expect(results[0]).toEqual(originalDiagnostics);
     expect(results[1]).toEqual(["Found 6 diagnostics in 2 files"]);
 
     const diagnosticsRepeatedFile = [[makeDiagnostic(111), makeDiagnostic(222), makeDiagnostic(333)],
         [makeDiagnostic(111), makeDiagnostic(222), makeDiagnostic(333)],
         [makeDiagnostic(444), makeDiagnostic(444)]];
-    const resultsRepeatedFile = filterDiagnosticsByErrorCode(diagnosticsRepeatedFile, default_codes);
+    const resultsRepeatedFile = filterDiagnosticsByFileAndErrorCode(diagnosticsRepeatedFile, default_codes);
     expect(resultsRepeatedFile[0]).toEqual(diagnosticsRepeatedFile);
     expect(resultsRepeatedFile[1]).toEqual(["Found 8 diagnostics in 3 files"]);
 })
@@ -49,20 +49,20 @@ test("filterDiagnostics_noErrorsInOpt_multiFiles", () => {
 
 test("filterDiagnostics_oneErrorInOpt_oneFile", () => {
     const originalDiagnostics = [[makeDiagnostic(111), makeDiagnostic(222), makeDiagnostic(333)]];
-    const results111 = filterDiagnosticsByErrorCode(originalDiagnostics, [111]);
+    const results111 = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [111]);
     expect(results111[0]).toEqual([[makeDiagnostic(111)]]);
     expect(results111[1]).toEqual(["Found 1 diagnostics with code 111"]);
 
-    const results333 = filterDiagnosticsByErrorCode(originalDiagnostics, [333]);
+    const results333 = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [333]);
     expect(results333[0]).toEqual([[makeDiagnostic(333)]]);
     expect(results333[1]).toEqual(["Found 1 diagnostics with code 333"]);
 
     const diagnosticsRepeatedError = [[makeDiagnostic(111), makeDiagnostic(333), makeDiagnostic(111)]];
-    const resultsRepeatedError = filterDiagnosticsByErrorCode(diagnosticsRepeatedError, [111]);
+    const resultsRepeatedError = filterDiagnosticsByFileAndErrorCode(diagnosticsRepeatedError, [111]);
     expect(resultsRepeatedError[0]).toEqual([[makeDiagnostic(111),makeDiagnostic(111)]]);
     expect(resultsRepeatedError[1]).toEqual(["Found 2 diagnostics with code 111"]);
 
-    const resultsRepeatedError333 = filterDiagnosticsByErrorCode(diagnosticsRepeatedError, [333]);
+    const resultsRepeatedError333 = filterDiagnosticsByFileAndErrorCode(diagnosticsRepeatedError, [333]);
     expect(resultsRepeatedError333[0]).toEqual([[makeDiagnostic(333)]]);
     expect(resultsRepeatedError333[1]).toEqual(["Found 1 diagnostics with code 333"]);
 })
@@ -70,7 +70,7 @@ test("filterDiagnostics_oneErrorInOpt_oneFile", () => {
 test("filterDiagnostics_oneErrorInOptNotFoundInOneFile", () => {
     const originalDiagnostics = [[makeDiagnostic(222), makeDiagnostic(222), makeDiagnostic(333)]];
 
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, [111]);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [111]);
     expect(results[0]).toEqual([]);
     expect(results[1]).toEqual(["No diagnostics found with code 111"]);
 })
@@ -78,7 +78,7 @@ test("filterDiagnostics_oneErrorInOptNotFoundInOneFile", () => {
 test("filterDiagnostics_manyErrorInOptNotFoundInOneFile", () => {
     const originalDiagnostics = [[makeDiagnostic(222), makeDiagnostic(222), makeDiagnostic(333)]];
 
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, [111, 999]);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [111, 999]);
     expect(results[0]).toEqual([]);
     expect(results[1]).toEqual(["No diagnostics found with code 111", "No diagnostics found with code 999"]);
 })
@@ -90,7 +90,7 @@ test("filterDiagnostics_oneErrorInOptNotFoundInManyFiles", () => {
                                     [makeDiagnostic(444), makeDiagnostic(444), makeDiagnostic(777)],
                                     [makeDiagnostic(777), makeDiagnostic(222), makeDiagnostic(777)],
                                     [makeDiagnostic(333), makeDiagnostic(222)]];
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, [111]);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [111]);
     expect(results[0]).toEqual([]);
     expect(results[1]).toEqual(["No diagnostics found with code 111"]);
 })
@@ -106,7 +106,7 @@ test("filterDiagnostics_oneErrorInOptSomeFoundInManyFiles", () => {
                                     [makeDiagnostic(444, "f7"), makeDiagnostic(444, "f7")],
                                     [makeDiagnostic(111, "f8")]
                                 ];
-    const results = filterDiagnosticsByErrorCode(originalDiagnostics, [111]);
+    const results = filterDiagnosticsByFileAndErrorCode(originalDiagnostics, [111]);
     expect(results[0]).toEqual([[makeDiagnostic(111, "f1")], 
                                 [makeDiagnostic(111, "f5")], 
                                 [makeDiagnostic(111, "f6"), makeDiagnostic(111, "f6")],


### PR DESCRIPTION
Previous functionality is still there, except now the user isn't required to provide a fix name or an error code to run the tool.

Changes are as follows:
- Allows the user to run the tool without providing error codes and fix names
- User can provide relative paths to the file(s) for which to find diagnostics (--file)
- If the repository contains previous changes, the user can choose to overwrite those changes and run ts-fix (--ignoreGitStatus)
- User can enable interactive mode and choose which fixes to apply (--interactiveMode)
- If a diagnostic has more than one fix, the user can choose to show these (--showMultiple) or let the tool pick the fix for each of those diagnostics
    
Missing
- test cases
- update documentation