### PR TITLE
`git status`-related fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ export const checkOptions = async (opt: Options): Promise<[string[], string[]]> 
 
   // Check git status if the write flag was provided and the output folder is the same as the project folder
   // Do not allow overwriting files with previous changes on them unless --ignoreGitStatus flag was provided
-  if (opt.write && path.dirname(opt.tsconfig) === opt.outputFolder) {
+  if (opt.write && path.dirname(opt.tsconfig) === opt.outputFolder && !opt.ignoreGitStatus) {
     let isModified = false;
     const status = await (getGitStatus(opt.tsconfig));
     const splitStatus = status.split(/\r?\n/);
@@ -120,7 +120,7 @@ export const checkOptions = async (opt: Options): Promise<[string[], string[]]> 
       const re = /[MARCD?]\s(package).+?(json)/g
       isModified = splitStatus.length && splitStatus[0] !== '' ? !(splitStatus.filter((text) => { return text.match(re) }).length === splitStatus.length) : false;
     }
-    if (isModified && !opt.ignoreGitStatus) {
+    if (isModified) {
       throw new Error(`Please provide the --ignoreGitStatus flag if you are sure you'ld like to override your exisiting changes`);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export interface Options {
 // Note: Only works if the git repository folder matches tsconfig folder
 const getGitStatus = (dir: string) => new Promise<string>((resolve) => {
   const dirPath = path.dirname(dir);
-  return exec(`git --git-dir="${dirPath + "\\.git"}" --work-tree="${dirPath}" status --porcelain`, (err, stdout) => {
+  return exec(`git --git-dir="${path.join(dirPath, ".git")}" --work-tree="${dirPath}" status --porcelain`, (err, stdout) => {
     if (err) {
       throw new Error(err.message);
     }


### PR DESCRIPTION
Two fixes for changes in #12:

1. Use `path.join` to construct a path (this was failing on POSIX systems)
2. Avoid calling `git status` altogether if user has set `ignoreGitStatus`. I was getting failures in my monorepo project due to it interpreting my package dir as the Git dir. I'm not sure why it passes `--git-dir` to `git status` (could just set the `exec`'s `cwd` to match `dir`?), but this change means that passing `ignoreGitStatus` allows users in situations like mine to bypass the issue entirely.