### PR TITLE
Mention install script to install tsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This tool is to automate the application of TypeScript codefixes across your Typ
 # Download
 If cloning from GitHub, after cloning, run
 ```
+npm install
 npm run build
 npm link
 ```


### PR DESCRIPTION
I followed the README instructions:

```bash
git clone git@github.com:microsoft/ts-fix.git
cd ts-fix
npm run build
```

This resulted in the following error:

> ts-fix@0.1.0 build
> tsc -p . && tsc -p test
> sh: 1: tsc: not found

To resolve this, `npm install` must be executed to ensure `tsc` is available.