### PR TITLE
Fix for Codefix being ignored on line 0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -435,7 +435,7 @@ export function getCodeFixesForFile(project: Project, diagnostics: readonly Diag
   // expects already filtered diagnostics
   const service = project.languageService;
   return flatMap(diagnostics, d => {
-    if (d.file && d.start && d.length) {
+    if (d.file && typeof d.start === "number" && d.length) {
       return service.getCodeFixesAtPosition(
         d.file.fileName,
         d.start,

--- a/test/integration/__snapshots__/addOneUnknown.shot
+++ b/test/integration/__snapshots__/addOneUnknown.shot
@@ -11,6 +11,9 @@ exports[`integration tests addOneUnknown 4 1`] = `
     "The project is being created...\\r\\n",
     "Using TypeScript 5.5.3",
     "\\r\\nFound 1 diagnostics with code 2352",
+    "Found 1 codefixes",
+    "Fixes to be applied: 1\\r\\nNo applied fixes: 0\\r\\n",
+    "\\r\\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
     "No changes remaining for ts-fix"
   ],

--- a/test/integration/__snapshots__/addOneUnknownToList.shot
+++ b/test/integration/__snapshots__/addOneUnknownToList.shot
@@ -11,6 +11,9 @@ exports[`integration tests addOneUnknownToList 5 1`] = `
     "The project is being created...\\r\\n",
     "Using TypeScript 5.5.3",
     "\\r\\nFound 1 diagnostics with code 2352",
+    "Found 1 codefixes",
+    "Fixes to be applied: 1\\r\\nNo applied fixes: 0\\r\\n",
+    "\\r\\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
     "No changes remaining for ts-fix"
   ],

--- a/test/integration/__snapshots__/addThreeUnknown.shot
+++ b/test/integration/__snapshots__/addThreeUnknown.shot
@@ -11,9 +11,9 @@ exports[`integration tests addThreeUnknown 6 1`] = `
     "The project is being created...\\r\\n",
     "Using TypeScript 5.5.3",
     "\\r\\nFound 3 diagnostics with code 2352",
-    "Found 2 codefixes",
-    "Fixes to be applied: 2\\r\\nNo applied fixes: 0\\r\\n",
-    "\\r\\nFound 1 diagnostics with code 2352",
+    "Found 3 codefixes",
+    "Fixes to be applied: 3\\r\\nNo applied fixes: 0\\r\\n",
+    "\\r\\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
     "No changes remaining for ts-fix"
   ],

--- a/test/integration/__snapshots__/twoErrorCodes.shot
+++ b/test/integration/__snapshots__/twoErrorCodes.shot
@@ -13,10 +13,10 @@ exports[`integration tests twoErrorCodes 9 1`] = `
     "Using TypeScript 5.5.3",
     "\\r\\nFound 2 diagnostics with code 4114",
     "\\r\\nFound 3 diagnostics with code 2352",
-    "Found 4 codefixes",
-    "Fixes to be applied: 4\\r\\nNo applied fixes: 0\\r\\n",
+    "Found 5 codefixes",
+    "Fixes to be applied: 5\\r\\nNo applied fixes: 0\\r\\n",
     "\\r\\nNo diagnostics found with code 4114",
-    "\\r\\nFound 1 diagnostics with code 2352",
+    "\\r\\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
     "No changes remaining for ts-fix"
   ],

--- a/test/integration/__snapshots__/twoFixNames.shot
+++ b/test/integration/__snapshots__/twoFixNames.shot
@@ -13,9 +13,9 @@ exports[`integration tests twoFixNames 10 1`] = `
     "Using TypeScript 5.5.3",
     "\\r\\nFound 6 diagnostics in 9 files",
     "Found 2 codefixes with name fixOverrideModifier",
-    "Found 2 codefixes with name addConvertToUnknownForNonOverlappingTypes",
-    "Fixes to be applied: 4\\r\\nNo applied fixes: 0\\r\\n",
-    "\\r\\nFound 2 diagnostics in 9 files",
+    "Found 3 codefixes with name addConvertToUnknownForNonOverlappingTypes",
+    "Fixes to be applied: 5\\r\\nNo applied fixes: 0\\r\\n",
+    "\\r\\nFound 1 diagnostics in 9 files",
     "No codefixes found with name fixOverrideModifier",
     "No codefixes found with name addConvertToUnknownForNonOverlappingTypes",
     "No changes remaining for ts-fix"


### PR DESCRIPTION
## Issue

The check is testing if the codefix start is truthy, to check if it is set, but this will fail when the line is 0.

## Solution

Fixed by explicitly checking if the start argument is a number.