### PR TITLE
`README.md`: Make the Example Usages easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ npm link
 
 
 # Example Usage
-`ts-fix -t path/to/tsconfig.json -f nameOfCodefix`
-`ts-fix -e 4114 --write`
-`ts-fix --interactiveMode --file relativePathToFile`
+```
+ts-fix -t path/to/tsconfig.json -f nameOfCodefix
+```
+
+```
+ts-fix -e 4114 --write
+```
+
+```
+ts-fix --interactiveMode --file relativePathToFile
+```
 
 # Flags 
 


### PR DESCRIPTION
The example usages are currently rendered all on the same line, making them hard to parse:

![image](https://github.com/user-attachments/assets/1f71e55f-dd7d-4274-8efb-0141d2bcd82c)

This PR separates them out:

![image](https://github.com/user-attachments/assets/2323f134-0f42-4dd7-9447-2e2812b507f2)
