### PR TITLE
Ensure text changes are applied in order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -460,25 +460,24 @@ function mergeChanges(arr1: TextChange[], arr2: TextChange[]): TextChange[] {
   let i = 0; 
   let j = 0;
 
-  // Traverse both arrays
   while (i < arr1.length && j < arr2.length) {
-      if (arr1[i].span.start < arr2[j].span.start) {
-          mergedArray.push(arr1[i]);
-          i++;
-      } else {
-          mergedArray.push(arr2[j]);
-          j++;
-      }
+    if (arr1[i].span.start < arr2[j].span.start) {
+        mergedArray.push(arr1[i]);
+        i++;
+    } else {
+        mergedArray.push(arr2[j]);
+        j++;
+    }
   }
 
   while (i < arr1.length) {
-      mergedArray.push(arr1[i]);
-      i++;
-  }
+    mergedArray.push(arr1[i]);
+    i++;
+}
 
   while (j < arr2.length) {
-      mergedArray.push(arr2[j]);
-      j++;
+    mergedArray.push(arr2[j]);
+    j++;
   }
 
   return mergedArray;

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,6 +455,34 @@ function getFileTextChangesFromCodeFix(codefix: CodeFixAction): readonly FileTex
   return codefix.changes;
 }
 
+function mergeChanges(arr1: TextChange[], arr2: TextChange[]): TextChange[] {
+  let mergedArray = [];
+  let i = 0; 
+  let j = 0;
+
+  // Traverse both arrays
+  while (i < arr1.length && j < arr2.length) {
+      if (arr1[i].span.start < arr2[j].span.start) {
+          mergedArray.push(arr1[i]);
+          i++;
+      } else {
+          mergedArray.push(arr2[j]);
+          j++;
+      }
+  }
+
+  while (i < arr1.length) {
+      mergedArray.push(arr1[i]);
+      i++;
+  }
+
+  while (j < arr2.length) {
+      mergedArray.push(arr2[j]);
+      j++;
+  }
+
+  return mergedArray;
+}
 export function getTextChangeDict(codefixes: readonly CodeFixAction[]): Map<string, TextChange[]> {
   let textChangeDict = new Map<string, TextChange[]>();
 
@@ -473,7 +501,7 @@ export function getTextChangeDict(codefixes: readonly CodeFixAction[]): Map<stri
       if (prevVal === undefined) {
         textChangeDict.set(key, value);
       } else {
-        textChangeDict.set(key, prevVal.concat(value));
+        textChangeDict.set(key, mergeChanges(prevVal, value));
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,18 +462,18 @@ function mergeChanges(arr1: TextChange[], arr2: TextChange[]): TextChange[] {
 
   while (i < arr1.length && j < arr2.length) {
     if (arr1[i].span.start < arr2[j].span.start) {
-        mergedArray.push(arr1[i]);
-        i++;
+      mergedArray.push(arr1[i]);
+      i++;
     } else {
-        mergedArray.push(arr2[j]);
-        j++;
+      mergedArray.push(arr2[j]);
+      j++;
     }
   }
 
   while (i < arr1.length) {
     mergedArray.push(arr1[i]);
     i++;
-}
+  }
 
   while (j < arr2.length) {
     mergedArray.push(arr2[j]);

--- a/test/unit/getTextChange.test.ts
+++ b/test/unit/getTextChange.test.ts
@@ -1,0 +1,34 @@
+import {  getTextChangeDict } from "../../src/index";
+import { CodeFixAction } from "typescript";
+
+const codefixes: CodeFixAction[] = [
+    {
+        fixName: 'fixOverrideModifier',
+        description: 'Add \'override\' modifier',
+        changes: [{ fileName: 'foo.ts', textChanges: [{ span: { start: 2, length: 0 }, newText: 'override ' }, { span: { start: 3, length: 0 }, newText: 'override ' }] }],
+        commands: undefined,
+        fixId: 'fixAddOverrideModifier'
+    },
+    {
+        fixName: 'fixOverrideModifier',
+        description: 'Add \'override\' modifier',
+        changes: [{ fileName: 'foo.ts', textChanges: [{ span: { start: 1, length: 0 }, newText: 'override ' }] }],
+        commands: undefined,
+        fixId: 'fixAddOverrideModifier'
+    },
+    {
+        fixName: 'addConvertToUnknownForNonOverlappingTypes',
+        description: 'Add \'unknown\' conversion for non-overlapping types',
+        changes: [{ fileName:  'foo.ts', textChanges: [{ span: { start: 8, length: 9 }, newText: '<unknown>["words"]' }] }],
+        commands: undefined,
+        fixId: 'addConvertToUnknownForNonOverlappingTypes'
+    },
+]
+
+test("should merge text changes in order", () => {
+    const result = getTextChangeDict(codefixes);
+    console.log(result.get('foo.ts'));
+    result.get('foo.ts');
+    expect(result).toBeDefined();
+})
+

--- a/test/unit/getTextChangeDict.test.ts
+++ b/test/unit/getTextChangeDict.test.ts
@@ -27,8 +27,8 @@ const codefixes: CodeFixAction[] = [
 
 test("should merge text changes in order", () => {
     const result = getTextChangeDict(codefixes);
-    console.log(result.get('foo.ts'));
-    result.get('foo.ts');
-    expect(result).toBeDefined();
+    const changes = result.get('foo.ts');
+    const spanStarts = changes?.map(c => c.span.start);
+    expect(spanStarts).toEqual([1, 2, 3, 8]);
 })
 


### PR DESCRIPTION
The text changes for each codeFix do indeed come in order, but when you have multiple codefixes and you [merge](https://github.com/microsoft/ts-fix/blob/main/src/index.ts#L476) them into a single list of text changes, you need to merge them in order.