### PR TITLE
remove lodash and use node util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "git-status": "^1.0.10",
         "import-cwd": "^3.0.0",
         "inquirer": "^8.0.0",
-        "lodash": "^4.17.21",
         "typescript": "^5.5.3",
         "yargs": "^16.2.0"
       },
@@ -25,7 +24,6 @@
         "@types/inquirer": "^8.2.1",
         "@types/jest": "^29.5.12",
         "@types/jest-specific-snapshot": "^0.5.9",
-        "@types/lodash": "^4.17.1",
         "@types/yargs": "^15.0.13",
         "esbuild": "^0.20.2",
         "esbuild-jest": "^0.5.0",
@@ -33,7 +31,7 @@
         "jest-specific-snapshot": "^8.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=17"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2641,12 +2639,6 @@
       "dependencies": {
         "@types/jest": "*"
       }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.1.tgz",
-      "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.12.10",
@@ -12142,12 +12134,6 @@
       "requires": {
         "@types/jest": "*"
       }
-    },
-    "@types/lodash": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.1.tgz",
-      "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
-      "dev": true
     },
     "@types/node": {
       "version": "20.12.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=14.17"
+    "node": ">=17"
   },
   "scripts": {
     "start": "tsc -p . --watch",
@@ -25,7 +25,6 @@
     "@types/inquirer": "^8.2.1",
     "@types/jest": "^29.5.12",
     "@types/jest-specific-snapshot": "^0.5.9",
-    "@types/lodash": "^4.17.1",
     "@types/yargs": "^15.0.13",
     "esbuild": "^0.20.2",
     "esbuild-jest": "^0.5.0",
@@ -37,7 +36,6 @@
     "git-status": "^1.0.10",
     "import-cwd": "^3.0.0",
     "inquirer": "^8.0.0",
-    "lodash": "^4.17.21",
     "typescript": "^5.5.3",
     "yargs": "^16.2.0"
   },

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -562,8 +562,8 @@ function trimEndImpl(s: string) {
 const trimStringEnd = !!String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
 
 function formatCodeSpan(file: SourceFile, start: number, length: number, indent: string, host: Host) {
-    const { line: firstLine, character: firstLineChar } = getLineAndCharacterOfPosition(file, start);
-    const { line: lastLine, character: lastLineChar } = getLineAndCharacterOfPosition(file, start + length);
+    const { line: firstLine } = getLineAndCharacterOfPosition(file, start);
+    const { line: lastLine } = getLineAndCharacterOfPosition(file, start + length);
     const lastLineInFile = getLineAndCharacterOfPosition(file, file.text.length).line;
 
     const hasMoreThanFiveLines = (lastLine - firstLine) >= 4;

--- a/test/integration/testHost.ts
+++ b/test/integration/testHost.ts
@@ -67,6 +67,6 @@ export class TestHost implements Host {
 
     getCanonicalFileName(fileName: string) { return fileName.toLowerCase() }
 
-    getCurrentDirectory() { return process.cwd() }
+    getCurrentDirectory() { return this.cwd }
 
 }


### PR DESCRIPTION
This replaces usage of lodash with node's own methods. `structuredClone` requires node >=17. I hope that won't be a problem. If you rather keep not change the minimum node version, I can revert to use `cloneDeep` from lodash.

I also removed some unused code.