### PR TITLE
uninstall unused git-status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "diff": "^5.2.0",
-        "git-status": "^1.0.10",
         "import-cwd": "^3.0.0",
         "inquirer": "^8.0.0",
         "lodash": "^4.17.21",
@@ -3654,14 +3653,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deffy": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.4.tgz",
-      "integrity": "sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==",
-      "dependencies": {
-        "typpy": "^2.0.0"
-      }
-    },
     "node_modules/define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -4251,14 +4242,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function.name": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.13.tgz",
-      "integrity": "sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==",
-      "dependencies": {
-        "noop6": "^1.0.1"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4304,16 +4287,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/git-status": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/git-status/-/git-status-1.0.10.tgz",
-      "integrity": "sha512-bxV60hbzMRjY/JarILltdppkfov0FcGyb9uytHjN7tjBFiibdhBJTddlxpaoBneQuDGem8vQy6UJ+SU89l7NlQ==",
-      "dependencies": {
-        "oargv": "^3.4.2",
-        "parse-git-status": "^0.1.0",
-        "spawno": "^1.0.1"
       }
     },
     "node_modules/glob": {
@@ -4916,11 +4889,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterate-object": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.4.tgz",
-      "integrity": "sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw=="
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -8367,11 +8335,6 @@
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
-    "node_modules/noop6": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.9.tgz",
-      "integrity": "sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA=="
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -8391,15 +8354,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/oargv": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/oargv/-/oargv-3.4.10.tgz",
-      "integrity": "sha512-SXaMANv9sr7S/dP0vj0+Ybipa47UE1ntTWQ2rpPRhC6Bsvfl+Jg03Xif7jfL0sWKOYWK8oPjcZ5eJ82t8AP/8g==",
-      "dependencies": {
-        "iterate-object": "^1.1.0",
-        "ul": "^5.0.0"
       }
     },
     "node_modules/object-copy": {
@@ -8654,14 +8608,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-git-status": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/parse-git-status/-/parse-git-status-0.1.0.tgz",
-      "integrity": "sha512-ngjxaxWtYrNIDYUWrCDcSAgtai3sELojyTauZVMyawYf+J9Cd6BvGQ/clGXrpmmFXkXj81E5zbOkGt8afsb+dw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8795,11 +8741,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/proc-output": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/proc-output/-/proc-output-1.0.8.tgz",
-      "integrity": "sha512-d5v2wFTIrfE7eyt5KqB+CwsaBAmYqKIVNZv3R3Hya96gImHm2Aul+x6MZHRaKI7Ijpr9cg3RiOCY6s1O4SvzFQ=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9595,14 +9536,6 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
-    "node_modules/spawno": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spawno/-/spawno-1.0.4.tgz",
-      "integrity": "sha512-euy9JLkCC2SvXNYZAi9WBTHDxbjSWNCaeLhLIH+BGW1Xb/3yKxoWOT2kanSS1a5wB0iukDYu79FJMNJsGW7azA==",
-      "dependencies": {
-        "proc-output": "^1.0.0"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9928,23 +9861,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typpy": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.13.tgz",
-      "integrity": "sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==",
-      "dependencies": {
-        "function.name": "^1.0.3"
-      }
-    },
-    "node_modules/ul": {
-      "version": "5.2.15",
-      "resolved": "https://registry.npmjs.org/ul/-/ul-5.2.15.tgz",
-      "integrity": "sha512-svLEUy8xSCip5IWnsRa0UOg+2zP0Wsj4qlbjTmX6GJSmvKMHADBuHOm1dpNkWqWPIGuVSqzUkV3Cris5JrlTRQ==",
-      "dependencies": {
-        "deffy": "^2.2.2",
-        "typpy": "^2.3.4"
       }
     },
     "node_modules/undici-types": {
@@ -12877,14 +12793,6 @@
         "clone": "^1.0.2"
       }
     },
-    "deffy": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.4.tgz",
-      "integrity": "sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==",
-      "requires": {
-        "typpy": "^2.0.0"
-      }
-    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -13339,14 +13247,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
-    "function.name": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.13.tgz",
-      "integrity": "sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==",
-      "requires": {
-        "noop6": "^1.0.1"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13375,16 +13275,6 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
-    },
-    "git-status": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/git-status/-/git-status-1.0.10.tgz",
-      "integrity": "sha512-bxV60hbzMRjY/JarILltdppkfov0FcGyb9uytHjN7tjBFiibdhBJTddlxpaoBneQuDGem8vQy6UJ+SU89l7NlQ==",
-      "requires": {
-        "oargv": "^3.4.2",
-        "parse-git-status": "^0.1.0",
-        "spawno": "^1.0.1"
-      }
     },
     "glob": {
       "version": "7.2.3",
@@ -13832,11 +13722,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterate-object": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.4.tgz",
-      "integrity": "sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw=="
     },
     "jest": {
       "version": "29.7.0",
@@ -16498,11 +16383,6 @@
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
-    "noop6": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.9.tgz",
-      "integrity": "sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA=="
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -16516,15 +16396,6 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
-      }
-    },
-    "oargv": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/oargv/-/oargv-3.4.10.tgz",
-      "integrity": "sha512-SXaMANv9sr7S/dP0vj0+Ybipa47UE1ntTWQ2rpPRhC6Bsvfl+Jg03Xif7jfL0sWKOYWK8oPjcZ5eJ82t8AP/8g==",
-      "requires": {
-        "iterate-object": "^1.1.0",
-        "ul": "^5.0.0"
       }
     },
     "object-copy": {
@@ -16710,11 +16581,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "parse-git-status": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/parse-git-status/-/parse-git-status-0.1.0.tgz",
-      "integrity": "sha512-ngjxaxWtYrNIDYUWrCDcSAgtai3sELojyTauZVMyawYf+J9Cd6BvGQ/clGXrpmmFXkXj81E5zbOkGt8afsb+dw=="
-    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -16808,11 +16674,6 @@
           "dev": true
         }
       }
-    },
-    "proc-output": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/proc-output/-/proc-output-1.0.8.tgz",
-      "integrity": "sha512-d5v2wFTIrfE7eyt5KqB+CwsaBAmYqKIVNZv3R3Hya96gImHm2Aul+x6MZHRaKI7Ijpr9cg3RiOCY6s1O4SvzFQ=="
     },
     "prompts": {
       "version": "2.4.2",
@@ -17431,14 +17292,6 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
-    "spawno": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spawno/-/spawno-1.0.4.tgz",
-      "integrity": "sha512-euy9JLkCC2SvXNYZAi9WBTHDxbjSWNCaeLhLIH+BGW1Xb/3yKxoWOT2kanSS1a5wB0iukDYu79FJMNJsGW7azA==",
-      "requires": {
-        "proc-output": "^1.0.0"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -17683,23 +17536,6 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ=="
-    },
-    "typpy": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.13.tgz",
-      "integrity": "sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==",
-      "requires": {
-        "function.name": "^1.0.3"
-      }
-    },
-    "ul": {
-      "version": "5.2.15",
-      "resolved": "https://registry.npmjs.org/ul/-/ul-5.2.15.tgz",
-      "integrity": "sha512-svLEUy8xSCip5IWnsRa0UOg+2zP0Wsj4qlbjTmX6GJSmvKMHADBuHOm1dpNkWqWPIGuVSqzUkV3Cris5JrlTRQ==",
-      "requires": {
-        "deffy": "^2.2.2",
-        "typpy": "^2.3.4"
-      }
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "diff": "^5.2.0",
-    "git-status": "^1.0.10",
     "import-cwd": "^3.0.0",
     "inquirer": "^8.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
`git-status` is not used for anything currently, so it can be uninstalled.