### PR TITLE
fix integration tests: filesWritten was not set

### DIFF
--- a/test/integration/__snapshots__/addMissingMember.shot
+++ b/test/integration/__snapshots__/addMissingMember.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addMissingMember",
   "args": [
     "-e",
-    "2339"
+    "2339",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,7 +14,8 @@
     "Fixes to be applied: 0\r\nNo applied fixes: 4\r\n",
     "No changes remaining for ts-fix",
     "\r\nThe fixes not applied by ts-fix for this project are:",
-    "fixMissingMember types.ts"
+    "fixMissingMember types.ts",
+    "\r\nNo changes made in any files"
   ],
   "remainingChanges": [],
   "filesWritten": {

--- a/test/integration/__snapshots__/addMissingOverride.shot
+++ b/test/integration/__snapshots__/addMissingOverride.shot
@@ -4,7 +4,9 @@
     "-e",
     "4114",
     "-f",
-    "fixOverrideModifier"
+    "fixOverrideModifier",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -14,11 +16,18 @@
     "Fixes to be applied: 2\r\nNo applied fixes: 0\r\n",
     "\r\nNo diagnostics found with code 4114",
     "No codefixes found with name fixOverrideModifier",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "class Base {\n  m() {}\n}\n\nclass Derived extends Base {\n  override m() {}\n}\n\nclass MoreDerived extends Derived {\n  override m() {}\n}\n"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/addMissingOverrideByError.shot
+++ b/test/integration/__snapshots__/addMissingOverrideByError.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addMissingOverrideByError",
   "args": [
     "-e",
-    "4114"
+    "4114",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,11 +14,18 @@
     "Fixes to be applied: 2\r\nNo applied fixes: 0\r\n",
     "\r\nNo diagnostics found with code 4114",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "class Base {\n  m() {}\n}\n\nclass Derived extends Base {\n  override m() {}\n}\n\nclass MoreDerived extends Derived {\n  override m() {}\n}\n"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/addMissingOverrideByFixName.shot
+++ b/test/integration/__snapshots__/addMissingOverrideByFixName.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addMissingOverrideByFixName",
   "args": [
     "-f",
-    "fixOverrideModifier"
+    "fixOverrideModifier",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,11 +14,18 @@
     "Fixes to be applied: 2\r\nNo applied fixes: 0\r\n",
     "\r\nFound 0 diagnostics in 8 files",
     "No codefixes found with name fixOverrideModifier",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "class Base {\n  m() {}\n}\n\nclass Derived extends Base {\n  override m() {}\n}\n\nclass MoreDerived extends Derived {\n  override m() {}\n}\n"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/addOneUnknown.shot
+++ b/test/integration/__snapshots__/addOneUnknown.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addOneUnknown",
   "args": [
     "-e",
-    "2352"
+    "2352",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,11 +14,18 @@
     "Fixes to be applied: 1\r\nNo applied fixes: 0\r\n",
     "\r\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "<object><unknown>\"words\";"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/addOneUnknownToList.shot
+++ b/test/integration/__snapshots__/addOneUnknownToList.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addOneUnknownToList",
   "args": [
     "-e",
-    "2352"
+    "2352",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,11 +14,18 @@
     "Fixes to be applied: 1\r\nNo applied fixes: 0\r\n",
     "\r\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "<string><unknown>[\"words\"];\n"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/addThreeUnknown.shot
+++ b/test/integration/__snapshots__/addThreeUnknown.shot
@@ -2,7 +2,9 @@
   "cwd": "cases/addThreeUnknown",
   "args": [
     "-e",
-    "2352"
+    "2352",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -12,11 +14,18 @@
     "Fixes to be applied: 3\r\nNo applied fixes: 0\r\n",
     "\r\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "<string><unknown>[\"words\"];\n\n<object><unknown>\"words\";\n\n<string><unknown>0 * (4 + 3) / 100;"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/multipleFixesInSameLine.shot
+++ b/test/integration/__snapshots__/multipleFixesInSameLine.shot
@@ -2,18 +2,30 @@
   "cwd": "cases/multipleFixesInSameLine",
   "args": [
     "-e",
-    "7044"
+    "7006",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
     "Using TypeScript 5.5.3",
-    "\r\nNo diagnostics found with code 7044",
+    "\r\nFound 2 diagnostics with code 7006",
+    "Found 2 codefixes",
+    "Fixes to be applied: 2\r\nNo applied fixes: 0\r\n",
+    "\r\nNo diagnostics found with code 7006",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated index.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "index.ts",
+        "function (a: any, b: any) {\n  return a + b;\n}"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/noDiagnostics.shot
+++ b/test/integration/__snapshots__/noDiagnostics.shot
@@ -2,14 +2,17 @@
   "cwd": "cases/noDiagnostics",
   "args": [
     "-e",
-    "4114"
+    "4114",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
     "Using TypeScript 5.5.3",
     "\r\nNo diagnostics found with code 4114",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nNo changes made in any files"
   ],
   "remainingChanges": [],
   "filesWritten": {

--- a/test/integration/__snapshots__/twoErrorCodes.shot
+++ b/test/integration/__snapshots__/twoErrorCodes.shot
@@ -3,7 +3,9 @@
   "args": [
     "-e",
     "4114",
-    "2352"
+    "2352",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -15,11 +17,23 @@
     "\r\nNo diagnostics found with code 4114",
     "\r\nNo diagnostics found with code 2352",
     "Found 0 codefixes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated addoverrides.ts",
+    "Updated addunknowns.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "addoverrides.ts",
+        "class Base {\n  m() {}\n}\n\nclass Derived extends Base {\n  override m() {}\n}\n\nclass MoreDerived extends Derived {\n  override m() {}\n}\n"
+      ],
+      [
+        "addunknowns.ts",
+        "<string><unknown>[\"words\"];\n\n<object><unknown>\"words\";\n\n<string><unknown>0 * (4 + 3) / 100;"
+      ]
+    ]
   }
 }

--- a/test/integration/__snapshots__/twoFixNames.shot
+++ b/test/integration/__snapshots__/twoFixNames.shot
@@ -3,7 +3,9 @@
   "args": [
     "-f",
     "fixOverrideModifier",
-    "addConvertToUnknownForNonOverlappingTypes"
+    "addConvertToUnknownForNonOverlappingTypes",
+    "-w",
+    "--ignoreGitStatus"
   ],
   "logs": [
     "The project is being created...\r\n",
@@ -15,11 +17,23 @@
     "\r\nFound 1 diagnostics in 9 files",
     "No codefixes found with name fixOverrideModifier",
     "No codefixes found with name addConvertToUnknownForNonOverlappingTypes",
-    "No changes remaining for ts-fix"
+    "No changes remaining for ts-fix",
+    "\r\nChanges were made in the following files:",
+    "Updated addoverrides.ts",
+    "Updated addunknowns.ts"
   ],
   "remainingChanges": [],
   "filesWritten": {
     "dataType": "Map",
-    "value": []
+    "value": [
+      [
+        "addoverrides.ts",
+        "class Base {\n  m() {}\n}\n\nclass Derived extends Base {\n  override m() {}\n}\n\nclass MoreDerived extends Derived {\n  override m() {}\n}\n"
+      ],
+      [
+        "addunknowns.ts",
+        "<string><unknown>[\"words\"];\n\n<object><unknown>\"words\";\n\n<string><unknown>0 * (4 + 3) / 100;"
+      ]
+    ]
   }
 }

--- a/test/integration/cases/multipleFixesInSameLine/cmd.txt
+++ b/test/integration/cases/multipleFixesInSameLine/cmd.txt
@@ -1,1 +1,1 @@
-ts-fix -e 7044
+ts-fix -e 7006

--- a/test/integration/cases/multipleFixesInSameLine/tsconfig.json
+++ b/test/integration/cases/multipleFixesInSameLine/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
     "types": [],
-    "noImplicitOverride": true
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
Integration tests were not really setting `filesWritten` in snapshots because the tests didn't specify `-w`. The tests also need to use `--ignoreGitStatus` or otherwise there will be error about missing `.git` directory. 

`addMissingMember` test is maybe not working correctly as it's not actually writing any changes to files. 